### PR TITLE
New pre-commit script

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ These hooks will:
 
     cd .git/hooks/ && ln -s ../../hooks/pre-commit .
 
+Alternatively, to only lint files that have been staged in git, use
+    cd .git/hooks/ && ln -s ../../hooks/pre-commit_staged pre-commit
+
 ### Setup Continuous Integration
 
 Continuous integration will run the following:

--- a/hooks/pre-commit_staged
+++ b/hooks/pre-commit_staged
@@ -1,0 +1,69 @@
+#!/bin/sh 
+
+# exit at the first error
+set -e
+
+# flake8 linting
+
+# Only extract the python files that git has staged; no need to lint WIP files that are not staged.
+
+# We'll use files to use intermediate results; it's easier to use grep on files.
+staged_file_name="staged_file.tmp"
+python_staged_file_name="python_staged_file.tmp"
+
+git diff --name-only --cached > $staged_file_name
+
+# Grep has the following behavior:
+#   the exit code is 0 if there is a match
+#   the exit code is 1 if there is no match
+#   the exit code is >1 if there is an error
+#
+# No match is a legitimate result, but the exit code of 1 is interpreted as an error by bash.
+# To work around this issue, we'll use
+#               grep [...] || [[ $? == 1]]
+# which has an exit code of 0 if there is a match or if there are no match.
+
+grep '.*py$' $staged_file_name > $python_staged_file_name || [[ $? == 1 ]]
+python_staged_files=`cat $python_staged_file_name`
+
+python_non_tests_staged_files=`grep -v '^tests' $python_staged_file_name || [[ $? == 1 ]]`
+
+rm $python_staged_file_name $staged_file_name
+
+
+if [ -z "${python_staged_files}" ]; then
+    echo "No python file to lint"
+else
+    flake8 --ignore D,W503 --max-line-length=120 $python_staged_files # Check everything but docstrings
+fi
+
+if [ -z "${python_non_tests_staged_files}" ]; then
+    echo "No non-test python file to docstring lint"
+else
+    flake8 --select D --ignore D104,D100,D401 --docstring-convention google --exclude tests/  $python_non_tests_staged_files  # Check only the docstrings
+fi
+
+
+# Raise error if any staged notebooks contain outputs
+GITDIR=$(git rev-parse --show-toplevel) # Full path to git working directory
+IPYNB_FILES=$(git diff --name-only --cached | grep .ipynb || true) # Find all committed notebooks
+if [ "$IPYNB_FILES" != "" ] && [ -z $ALLOW_IPYNB ]; then
+    for f in $IPYNB_FILES
+    do
+        DIFF=$(jupyter nbconvert --log-level ERROR --ClearOutputPreprocessor.enabled=True --ClearMetadataPreprocessor.enabled=True --to notebook --stdout $GITDIR/$f | diff $GITDIR/$f  - || :)
+        if [ "$DIFF" != "" ]; then
+            echo "
+            The notebook $GITDIR/$f contains outputs.
+            Remove them all before committing. 
+            ***Hint*** use the command:
+
+            jupyter nbconvert --ClearOutputPreprocessor.enabled=True --ClearMetadataPreprocessor.enabled=True --to notebook --inplace $GITDIR/$f
+
+	    To ignore this error, and add a notebook with outputs, use:
+
+	    export ALLOW_IPYNB=1
+            "
+            exit 1
+        fi
+    done
+fi

--- a/hooks/pre-commit_staged
+++ b/hooks/pre-commit_staged
@@ -35,12 +35,14 @@ if [ -z "${python_staged_files}" ]; then
     echo "No python file to lint"
 else
     flake8 --ignore D,W503 --max-line-length=120 $python_staged_files # Check everything but docstrings
+    isort --check $python_staged_files # Check imports
 fi
 
 if [ -z "${python_non_tests_staged_files}" ]; then
     echo "No non-test python file to docstring lint"
 else
     flake8 --select D --ignore D104,D100,D401 --docstring-convention google --exclude tests/  $python_non_tests_staged_files  # Check only the docstrings
+    isort --check $python_non_tests_staged_files # Check imports
 fi
 
 

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
     install_requires=[
         'flake8==4.0.1',
         'flake8-docstrings==1.6.0',
+        'isort==5.13.2',
         'gitpython==3.1.27',
         'jupyter==1.0.0',
         'jinja2==3.1.2',


### PR DESCRIPTION
Here's a better pre-commit script that I created for another project. With this script, git won't complain for
files that are not staged, so we don't get a deluge of complaints every time we want to commit anything. 
This is useful in a development context where there may be a bunch of ad hoc, non committed files floating around.

The original pre-commit script is still what is being run in CI.