### PR TITLE
Sanity check

### DIFF
--- a/crystal_diffusion/analysis/perturbation_kernel_analysis.py
+++ b/crystal_diffusion/analysis/perturbation_kernel_analysis.py
@@ -1,0 +1,70 @@
+"""Perturbation Kernel Analysis.
+
+This script computes and plots the perturbation kernel K for various values of sigma, showing
+the behavior for different normalization, sigma K and sigma^2 K.
+"""
+import matplotlib.pyplot as plt
+import torch
+
+from crystal_diffusion import ANALYSIS_RESULTS_DIR
+from crystal_diffusion.analysis import PLEASANT_FIG_SIZE, PLOT_STYLE_PATH
+from crystal_diffusion.score.wrapped_gaussian_score import \
+    get_sigma_normalized_score
+
+plt.style.use(PLOT_STYLE_PATH)
+
+sigma_max = 0.5
+
+if __name__ == '__main__':
+
+    coordinates = torch.linspace(start=0, end=1, steps=1001)[:-1]
+    sigmas = torch.linspace(start=0, end=sigma_max, steps=101)[1:]
+
+    X, SIG = torch.meshgrid(coordinates, sigmas, indexing='xy')
+
+    # Avoid non-contiguous bjorks
+    X = X.clone()
+    SIG = SIG.clone()
+
+    sigma_normalized_scores = get_sigma_normalized_score(X, SIG, kmax=4).numpy()
+    sigma2_normalized_scores = SIG * sigma_normalized_scores
+
+    # A first figure to compare the "smart" and the "brute force" results
+    fig_size = (1.25 * PLEASANT_FIG_SIZE[0], 1.25 * PLEASANT_FIG_SIZE[1])
+    fig = plt.figure(figsize=fig_size)
+    fig.suptitle("Different Normalizations of the Perturbation Kernel, $K(x, \\sigma)$")
+
+    left, right, bottom, top = 0, 1., 0., sigma_max
+    extent = [left, right, bottom, top]
+
+    ax1 = fig.add_subplot(221)
+    ax2 = fig.add_subplot(222)
+
+    ax3 = fig.add_subplot(223)
+    ax4 = fig.add_subplot(224)
+
+    label1 = "$\\sigma \\times K(x, \\sigma)$"
+    label2 = "$\\sigma^2 \\times K(x, \\sigma)$"
+
+    for label, scores, ax in zip([label1, label2], [sigma_normalized_scores, sigma2_normalized_scores], [ax1, ax3]):
+
+        ax.set_title(label)
+        image = ax.imshow(scores, origin="lower", cmap='jet', extent=extent)
+        ax.set_xlabel("x")
+        ax.set_ylabel("$\\sigma$")
+        _ = fig.colorbar(image, shrink=0.75, ax=ax)
+
+    for index in [0, 19, 39, 99]:
+        sigma = sigmas[index]
+        for ax, scores in zip([ax2, ax4], [sigma_normalized_scores, sigma2_normalized_scores]):
+            ax.plot(coordinates, scores[index], ls='-', lw=2, label=f'$\\sigma = {sigma:4.3f}$')
+
+    for ax in [ax2, ax4]:
+        ax.legend(loc=0)
+        ax.set_xlim([-0.05, 1.05])
+        ax.set_xlabel("x")
+    ax2.set_ylabel("$\\sigma \\times K(x, \\sigma)$")
+    ax4.set_ylabel("$\\sigma^2 \\times K(x, \\sigma)$")
+
+    fig.tight_layout()
+    fig.savefig(ANALYSIS_RESULTS_DIR.joinpath("perturbation_kernel_with_different_normalizations.png"))

--- a/crystal_diffusion/models/callbacks.py
+++ b/crystal_diffusion/models/callbacks.py
@@ -1,13 +1,103 @@
 import dataclasses
 
+import matplotlib.pyplot as plt
+import torch
 from pytorch_lightning import Callback
+from pytorch_lightning.loggers import TensorBoardLogger
+
+from crystal_diffusion.analysis import PLEASANT_FIG_SIZE
 
 
 class HPLoggingCallback(Callback):
     """This callback is responsible for logging hyperparameters."""
+
     def on_train_start(self, trainer, pl_module):
         """Log hyperparameters when training starts."""
-        assert hasattr(pl_module, 'hyper_params'), \
-            "The lightning module should have a hyper_params attribute for HP logging."
+        assert hasattr(
+            pl_module, "hyper_params"
+        ), "The lightning module should have a hyper_params attribute for HP logging."
         hp_dict = dataclasses.asdict(pl_module.hyper_params)
         trainer.logger.log_hyperparams(hp_dict)
+
+
+class TensorBoardDebuggingLoggingCallback(Callback):
+    """Base class to log debugging information for plotting on TensorBoard."""
+
+    def __init__(self):
+        """Init method."""
+        self.training_step_outputs = []
+
+    @staticmethod
+    def _get_tensorboard_logger(trainer):
+        if type(trainer.logger) == TensorBoardLogger:
+            return trainer.logger.experiment
+        return None
+
+    def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
+        """Action to perform at the end of a training batch."""
+        if self._get_tensorboard_logger(trainer) is None:
+            return
+        self.training_step_outputs.append(outputs)
+
+    def on_train_epoch_end(self, trainer, pl_module):
+        """Action to perform at the end of a training epoch."""
+        tbx_logger = self._get_tensorboard_logger(trainer)
+        if tbx_logger is None:
+            return
+
+        if pl_module.global_step % trainer.log_every_n_steps == 0:
+            self.log_artifact(pl_module, tbx_logger)
+        # free up the memory
+        self.training_step_outputs.clear()
+
+    def log_artifact(self, pl_module, tbx_logger):
+        """This method must create logging artifacts and log to the tbx logger."""
+        raise NotImplementedError(
+            "This method should be implemented to specific logging."
+        )
+
+
+class TensorboardHistogramLoggingCallback(TensorBoardDebuggingLoggingCallback):
+    """This callback will log histograms of the predictions on tensorboard."""
+
+    def log_artifact(self, pl_module, tbx_logger):
+        """Create artifact and log to tensorboard."""
+        targets = []
+        predictions = []
+        for output in self.training_step_outputs:
+            targets.append(output["target_normalized_conditional_scores"].flatten())
+            predictions.append(output["predicted_normalized_scores"].flatten())
+
+        targets = torch.cat(targets)
+        predictions = torch.cat(predictions)
+
+        tbx_logger.add_histogram(
+            "train/targets", targets, global_step=pl_module.global_step
+        )
+        tbx_logger.add_histogram(
+            "train/predictions", predictions, global_step=pl_module.global_step
+        )
+        tbx_logger.add_histogram(
+            "train/errors", targets - predictions, global_step=pl_module.global_step
+        )
+
+
+class TensorboardSamplesLoggingCallback(TensorBoardDebuggingLoggingCallback):
+    """This callback will log histograms of the labels, predictions and errors on tensorboard."""
+
+    def log_artifact(self, pl_module, tbx_logger):
+        """Create artifact and log to tensorboard."""
+        list_xt = []
+        list_sigmas = []
+        for output in self.training_step_outputs:
+            list_xt.append(output["noisy_relative_positions"].flatten())
+            list_sigmas.append(output["sigmas"].flatten())
+        list_xt = torch.cat(list_xt)
+        list_sigmas = torch.cat(list_sigmas)
+        fig = plt.figure(figsize=PLEASANT_FIG_SIZE)
+        ax = fig.add_subplot(111)
+        ax.set_title(f"Position Samples: global step = {pl_module.global_step}")
+        ax.set_ylabel("$\\sigma$")
+        ax.set_xlabel("position samples $x(t)$")
+        ax.plot(list_xt, list_sigmas, "bo")
+        tbx_logger.add_figure("train/samples", fig, global_step=pl_module.global_step)

--- a/crystal_diffusion/models/callbacks.py
+++ b/crystal_diffusion/models/callbacks.py
@@ -1,0 +1,13 @@
+import dataclasses
+
+from pytorch_lightning import Callback
+
+
+class HPLoggingCallback(Callback):
+    """This callback is responsible for logging hyperparameters."""
+    def on_train_start(self, trainer, pl_module):
+        """Log hyperparameters when training starts."""
+        assert hasattr(pl_module, 'hyper_params'), \
+            "The lightning module should have a hyper_params attribute for HP logging."
+        hp_dict = dataclasses.asdict(pl_module.hyper_params)
+        trainer.logger.log_hyperparams(hp_dict)

--- a/crystal_diffusion/models/position_diffusion_lightning_model.py
+++ b/crystal_diffusion/models/position_diffusion_lightning_model.py
@@ -136,7 +136,10 @@ class PositionDiffusionLightningModel(pl.LightningModule):
         )
 
         output = dict(loss=loss,
-                      predicted_normalized_scores=predicted_normalized_scores,
+                      real_relative_positions=x0,
+                      noisy_relative_positions=xt,
+                      sigmas=sigmas,
+                      predicted_normalized_scores=predicted_normalized_scores.detach(),
                       target_normalized_conditional_scores=target_normalized_conditional_scores)
         return output
 
@@ -204,16 +207,18 @@ class PositionDiffusionLightningModel(pl.LightningModule):
         self.log("train_loss", loss)
         self.log("epoch", self.current_epoch)
         self.log("step", self.global_step)
-        return loss  # this function is required, as the loss returned here is used for backprop
+        return output
 
     def validation_step(self, batch, batch_idx):
         """Runs a prediction step for validation, logging the loss."""
         output = self._generic_step(batch, batch_idx)
         loss = output["loss"]
         self.log("val_loss", loss)
+        return output
 
     def test_step(self, batch, batch_idx):
         """Runs a prediction step for testing, logging the loss."""
         output = self._generic_step(batch, batch_idx)
         loss = output["loss"]
         self.log("test_loss", loss)
+        return output

--- a/crystal_diffusion/models/position_diffusion_lightning_model.py
+++ b/crystal_diffusion/models/position_diffusion_lightning_model.py
@@ -124,16 +124,21 @@ class PositionDiffusionLightningModel(pl.LightningModule):
 
         xt = self.noisy_position_sampler.get_noisy_position_sample(x0, sigmas)
 
-        target_normalized_scores = self._get_target_normalized_score(xt, x0, sigmas)
+        # The target is nabla log p_{t|0} (xt | x0): it is NOT the "score", but rather a "conditional" (on x0) score.
+        target_normalized_conditional_scores = self._get_target_normalized_score(xt, x0, sigmas)
 
         predicted_normalized_scores = self._get_predicted_normalized_score(
             xt, noise_sample.time
         )
 
         loss = torch.nn.functional.mse_loss(
-            predicted_normalized_scores, target_normalized_scores, reduction="mean"
+            predicted_normalized_scores, target_normalized_conditional_scores, reduction="mean"
         )
-        return loss
+
+        output = dict(loss=loss,
+                      predicted_normalized_scores=predicted_normalized_scores,
+                      target_normalized_conditional_scores=target_normalized_conditional_scores)
+        return output
 
     def _get_target_normalized_score(
         self,
@@ -194,7 +199,8 @@ class PositionDiffusionLightningModel(pl.LightningModule):
 
     def training_step(self, batch, batch_idx):
         """Runs a prediction step for training, returning the loss."""
-        loss = self._generic_step(batch, batch_idx)
+        output = self._generic_step(batch, batch_idx)
+        loss = output["loss"]
         self.log("train_loss", loss)
         self.log("epoch", self.current_epoch)
         self.log("step", self.global_step)
@@ -202,10 +208,12 @@ class PositionDiffusionLightningModel(pl.LightningModule):
 
     def validation_step(self, batch, batch_idx):
         """Runs a prediction step for validation, logging the loss."""
-        loss = self._generic_step(batch, batch_idx)
+        output = self._generic_step(batch, batch_idx)
+        loss = output["loss"]
         self.log("val_loss", loss)
 
     def test_step(self, batch, batch_idx):
         """Runs a prediction step for testing, logging the loss."""
-        loss = self._generic_step(batch, batch_idx)
+        output = self._generic_step(batch, batch_idx)
+        loss = output["loss"]
         self.log("test_loss", loss)

--- a/sanity_checks/overfit_fake_data.py
+++ b/sanity_checks/overfit_fake_data.py
@@ -1,37 +1,61 @@
 """Overfit fake data.
 
-A simple sanity check experiment to verify that we can overfit a batch of random data.
+A simple sanity check experiment to check the learning behavior of the position diffusion model.
+The training data is taken to be a large batch of identical configurations composed of one atom in 1D at the origin.
+This highly artificial case is useful to sanity check that the code behaves as expected:
+ -  the loss should converge towards zero
+ -  the trained score network should reproduce the perturbation kernel, at least in the regions where it is sampled.
 """
 import os
 
+import matplotlib.pyplot as plt
 import pytorch_lightning
 import torch
 from pytorch_lightning import Trainer
+from pytorch_lightning.callbacks import LearningRateMonitor
 from pytorch_lightning.loggers import TensorBoardLogger
 from torch.utils.data import DataLoader
 
+from crystal_diffusion import ANALYSIS_RESULTS_DIR
+from crystal_diffusion.analysis import PLEASANT_FIG_SIZE, PLOT_STYLE_PATH
+from crystal_diffusion.models.callbacks import (
+    HPLoggingCallback, TensorboardHistogramLoggingCallback,
+    TensorboardSamplesLoggingCallback)
 from crystal_diffusion.models.optimizer import (OptimizerParameters,
                                                 ValidOptimizerNames)
 from crystal_diffusion.models.position_diffusion_lightning_model import (
     PositionDiffusionLightningModel, PositionDiffusionParameters)
 from crystal_diffusion.models.score_network import MLPScoreNetworkParameters
 from crystal_diffusion.samplers.variance_sampler import NoiseParameters
+from crystal_diffusion.score.wrapped_gaussian_score import \
+    get_sigma_normalized_score
 from sanity_checks import SANITY_CHECK_FOLDER
 
-batch_size = 16
-number_of_atoms = 4
-spatial_dimension = 2
+plt.style.use(PLOT_STYLE_PATH)
+
+batch_size = 4096
+number_of_atoms = 1
+spatial_dimension = 1
+total_time_steps = 100
+
+sigma_min = 0.005
+sigma_max = 0.5
+
+lr = 0.01
+max_epochs = 3000
+
+hidden_dimensions = [64, 128, 256]
+
 
 score_network_parameters = MLPScoreNetworkParameters(
     number_of_atoms=number_of_atoms,
-    hidden_dim=32,
+    hidden_dimensions=hidden_dimensions,
     spatial_dimension=spatial_dimension,
 )
 
-optimizer_parameters = OptimizerParameters(name=ValidOptimizerNames("adam"),
-                                           learning_rate=0.01)
+optimizer_parameters = OptimizerParameters(name=ValidOptimizerNames("adam"), learning_rate=lr)
 
-noise_parameters = NoiseParameters(total_time_steps=10)
+noise_parameters = NoiseParameters(total_time_steps=total_time_steps, sigma_min=sigma_min, sigma_max=sigma_max)
 
 hyper_params = PositionDiffusionParameters(
     score_network_parameters=score_network_parameters,
@@ -45,12 +69,67 @@ tbx_logger = TensorBoardLogger(save_dir=os.path.join(SANITY_CHECK_FOLDER, "tenso
 if __name__ == '__main__':
 
     pytorch_lightning.seed_everything(123)
-
-    all_positions = torch.rand(batch_size, number_of_atoms, spatial_dimension)
+    all_positions = torch.zeros(batch_size, number_of_atoms, spatial_dimension)
     data = [dict(relative_positions=configuration) for configuration in all_positions]
     train_dataloader = DataLoader(data, batch_size=batch_size)
 
     lightning_model = PositionDiffusionLightningModel(hyper_params)
 
-    trainer = Trainer(accelerator='cpu', max_epochs=10000, logger=tbx_logger, log_every_n_steps=1)
+    trainer = Trainer(accelerator='cpu',
+                      max_epochs=max_epochs,
+                      logger=tbx_logger,
+                      log_every_n_steps=50,
+                      callbacks=[HPLoggingCallback(),
+                                 TensorboardHistogramLoggingCallback(),
+                                 TensorboardSamplesLoggingCallback(),
+                                 LearningRateMonitor(logging_interval='step')])
     trainer.fit(lightning_model, train_dataloaders=train_dataloader)
+
+    fig = plt.figure(figsize=PLEASANT_FIG_SIZE)
+    fig.suptitle("Predictions, Targets and Errors within 2 $\\sigma$ of Data Point")
+    ax1 = fig.add_subplot(121)
+    ax2 = fig.add_subplot(122)
+    ax1.set_ylabel('$\\sigma \\times S_{\\theta}(x, t)$')
+    ax2.set_ylabel('$\\sigma \\times S_{\\theta}(x, t) - \\sigma \\nabla \\log P(x | 0)$')
+    ax1.set_xlabel('$x$')
+    ax2.set_xlabel('$x$')
+
+    list_x = torch.linspace(0, 1, 1001)[:-1]
+
+    times = torch.tensor([0.25, 0.75, 1.])
+    sigmas = lightning_model.variance_sampler._create_sigma_array(lightning_model.variance_sampler.noise_parameters,
+                                                                  times)
+
+    with torch.no_grad():
+        for time, sigma in zip(times, sigmas):
+            times = time * torch.ones(1000).reshape(-1, 1)
+
+            sigma_normalized_kernel = get_sigma_normalized_score(list_x,
+                                                                 sigma * torch.ones_like(list_x),
+                                                                 kmax=4)
+            predicted_normalized_scores = lightning_model._get_predicted_normalized_score(list_x.reshape(-1, 1, 1),
+                                                                                          times).flatten()
+
+            error = predicted_normalized_scores - sigma_normalized_kernel
+
+            # only plot the errors in the sampling region!
+            m1 = list_x < 2 * sigma
+            m2 = 1. - list_x < 2 * sigma
+
+            lines = ax1.plot(list_x[m1], predicted_normalized_scores[m1], lw=1, label='PREDICTION')
+            color = lines[0].get_color()
+            ax1.plot(list_x[m2], predicted_normalized_scores[m2], lw=2, color=color, label='_none_')
+
+            ax1.plot(list_x[m1], sigma_normalized_kernel[m1], '--', lw=2, color=color, label='TARGET')
+            ax1.plot(list_x[m2], sigma_normalized_kernel[m2], '--', lw=2, color=color, label='_none_')
+
+            ax2.plot(list_x[m1], error[m1], '-', color=color,
+                     label=f't = {time:4.3f}, $\\sigma$ = {sigma:4.3f}')
+            ax2.plot(list_x[m2], error[m2], '-', color=color, label='_none_')
+
+    for ax in [ax1, ax2]:
+        ax.set_xlim([-0.05, 1.05])
+        ax.legend(loc=0)
+
+    fig.tight_layout()
+    fig.savefig(ANALYSIS_RESULTS_DIR.joinpath("overfit_fake_data_trained_model_errors.png"))

--- a/tests/models/test_position_diffusion_lightning_model.py
+++ b/tests/models/test_position_diffusion_lightning_model.py
@@ -69,7 +69,7 @@ class TestPositionDiffusionLightningModel:
     def hyper_params(self, number_of_atoms, spatial_dimension):
         score_network_parameters = MLPScoreNetworkParameters(
             number_of_atoms=number_of_atoms,
-            hidden_dim=16,
+            hidden_dimensions=[4, 8, 16],
             spatial_dimension=spatial_dimension,
         )
 

--- a/tests/models/test_score_network.py
+++ b/tests/models/test_score_network.py
@@ -74,6 +74,7 @@ class TestScoreNetworkCheck:
 
 
 @pytest.mark.parametrize("spatial_dimension", [2, 3])
+@pytest.mark.parametrize("hidden_dimensions", [[16], [8, 16], [8, 16, 32]])
 class TestMLPScoreNetwork:
 
     @pytest.fixture()
@@ -101,10 +102,10 @@ class TestMLPScoreNetwork:
         return {BaseScoreNetwork.position_key: positions, BaseScoreNetwork.timestep_key: times}
 
     @pytest.fixture()
-    def score_network(self, number_of_atoms, spatial_dimension):
+    def score_network(self, number_of_atoms, spatial_dimension, hidden_dimensions):
         hyper_params = MLPScoreNetworkParameters(spatial_dimension=spatial_dimension,
                                                  number_of_atoms=number_of_atoms,
-                                                 hidden_dim=16)
+                                                 hidden_dimensions=hidden_dimensions)
         return MLPScoreNetwork(hyper_params)
 
     def test_check_batch_bad(self, score_network, bad_batch):


### PR DESCRIPTION
This PR mostly builds an ad hoc sanity check experiment to better understand the training behaviour of the position diffusion model. 
1. the MLP score network is improved to have a user-defined number of layers
2. the output of the `[...]_step` is now a dictionary with various useful quantities, not just the loss
3. I create various `callbacks` to log and plot to tensorboard. I think this is super nice, keeping the main business code simple and clean. My callbacks may not be very efficient, accumulating a lot of data and not being careful to be on the master node: they are only meant for sanity checking/debugging, we wouldn't use them in production!

4. I plot the "diffusion kernel" to see what the labels look like: it might be suspicious at first glance that $\sigma K$ can become very large (especially when $\sigma$ is small). It might thus be tempting to use $\sigma^2 K$ as the target labels.

![perturbation_kernel_with_different_normalizations](https://github.com/mila-iqia/diffusion_for_multi_scale_molecular_dynamics/assets/6283214/b20d8a2e-7c28-4d26-aeed-19fbef5dad9c)

5. **However**, by running the sanity check experiment, we can see that the score network is never exposed to large values of $\sigma K$

<img width="985" alt="Screenshot 2024-03-22 at 9 29 36 AM" src="https://github.com/mila-iqia/diffusion_for_multi_scale_molecular_dynamics/assets/6283214/e323b730-b523-47f0-b33e-9d8d4edf38d5">

which is confirmed by the distributions of target labels (ie, values of $\sigma K$)
<img width="1034" alt="Screenshot 2024-03-22 at 9 30 49 AM" src="https://github.com/mila-iqia/diffusion_for_multi_scale_molecular_dynamics/assets/6283214/c413c2b7-2040-4195-ab5a-cc234c82aa75">

I also systematically plot what the model predictions and errors look like at the end of training:
![overfit_fake_data_trained_model_errors](https://github.com/mila-iqia/diffusion_for_multi_scale_molecular_dynamics/assets/6283214/c48a8b88-a7ab-4bb1-bd9f-8b2410e9c879)


The loss gets smaller, but it is difficult to take it down to machine-epsilon: as we discussed, this might be a scheduler effect. 

<img width="646" alt="Screenshot 2024-03-22 at 9 27 14 AM" src="https://github.com/mila-iqia/diffusion_for_multi_scale_molecular_dynamics/assets/6283214/a39137f3-3672-4c48-a7bf-80c387b589c7">


**At this point, I'm satisfied that the code works as it should.**
