### PR TITLE
Convert score network input to mace graph input

### DIFF
--- a/crystal_diffusion/callbacks/sampling_callback.py
+++ b/crystal_diffusion/callbacks/sampling_callback.py
@@ -122,7 +122,11 @@ class DiffusionSamplingCallback(Callback):
         pc_sampler = AnnealedLangevinDynamicsSampler(sigma_normalized_score_network=sigma_normalized_score_network,
                                                      **sampler_parameters)
         logger.info("Draw samples")
-        samples = pc_sampler.sample(self.sampling_parameters.number_of_samples, device=pl_model.device)
+        # TODO we will have to sample unit cell dimensions at some points instead of working with fixed size
+        unit_cell = torch.diag(torch.Tensor(self.sampling_parameters.cell_dimensions)).to(pl_model.device)
+
+        samples = pc_sampler.sample(self.sampling_parameters.number_of_samples, device=pl_model.device,
+                                    unit_cell=unit_cell)
 
         batch_relative_positions = samples.cpu().numpy()
         return batch_relative_positions

--- a/crystal_diffusion/callbacks/sampling_callback.py
+++ b/crystal_diffusion/callbacks/sampling_callback.py
@@ -124,6 +124,7 @@ class DiffusionSamplingCallback(Callback):
         logger.info("Draw samples")
         # TODO we will have to sample unit cell dimensions at some points instead of working with fixed size
         unit_cell = torch.diag(torch.Tensor(self.sampling_parameters.cell_dimensions)).to(pl_model.device)
+        unit_cell = unit_cell.unsqueeze(0).repeat(self.sampling_parameters.number_of_samples, 1, 1)
 
         samples = pc_sampler.sample(self.sampling_parameters.number_of_samples, device=pl_model.device,
                                     unit_cell=unit_cell)

--- a/crystal_diffusion/models/mace_utils.py
+++ b/crystal_diffusion/models/mace_utils.py
@@ -1,0 +1,56 @@
+from typing import AnyStr, Dict, Tuple
+
+import torch
+from torch_geometric.data import Data
+
+
+def get_adj_matrix(num_edge: int, cell_size: float) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Create the adjacency and shift matrices.
+
+    Random matrices for now. Placeholder.
+
+    Args:
+        num_edge: number of edges to place in the graph
+        cell_size: size of the unit cell in Angstrom to get shift in Angstrom
+
+    Returns:
+        adjacency matrix as a [2, num_edge] tensor, and shift matrix as a [num_edge, 3] tensor
+    """
+    adj = torch.randint(0, 2, size=(2, num_edge))
+    shift = torch.randint(-1, 2, size=(num_edge, 3)) * cell_size
+    return adj, shift
+
+
+def input_to_mace(x: Dict[AnyStr, torch.Tensor], unit_cell_key: str) -> Data:
+    """Convert score network input to MACE input.
+
+    Args:
+        x: score network input dictionary
+        unit_cell_key: keyword argument to find the cell definition
+
+    Returns:
+        pytorch-geometric graph data compatible with MACE forward
+    """
+    batchsize = x['abs_positions'].size(0)
+    n_atom_per_graph = x['abs_positions'].size(1)
+    device = x['abs_positions'].device
+    adj_matrix, shift_matrix = get_adj_matrix(torch.randint(2, (batchsize * n_atom_per_graph) ** 2))  # TODO placeholder
+    # node features are int corresponding to atom type
+    node_attrs = torch.ones(batchsize, 1)  # TODO handle different type of atoms
+    positions = x['abs_positions'].view(-1, x['abs_positions'].size(-1))  # [batchsize * natoms, spatial dimension]
+    # pointer tensor that yields the first node index for each batch - this is a fixed tensor in our case
+    ptr = torch.arange(0, n_atom_per_graph * batchsize + 1, step=n_atom_per_graph)  # 0, natoms, 2 * natoms, ...
+    # batch tensor maps a node to a batch index - in our case, this would be 0, 0, 0, ..., 0, 1, 1, ..., 1, 2, 2, ...
+    batch_tensor = torch.repeat_interleave(torch.arange(0, batchsize), n_atom_per_graph)
+    cell = x[unit_cell_key]  # batch, spatial_dimension, spatial_dimension
+    cell = cell.view(-1, cell.size(-1))  # batch * spatial_dimension, spatial_dimension
+    # create the pytorch-geometric graph
+    graph_data = Data(edge_index=adj_matrix,
+                      node_attrs=node_attrs.to(device),
+                      positions=positions,
+                      ptr=ptr.to(device),
+                      batch=batch_tensor.to(device),
+                      shifts=shift_matrix,
+                      cell=cell
+                      )
+    return graph_data

--- a/crystal_diffusion/models/mace_utils.py
+++ b/crystal_diffusion/models/mace_utils.py
@@ -34,9 +34,10 @@ def input_to_mace(x: Dict[AnyStr, torch.Tensor], unit_cell_key: str) -> Data:
     batchsize = x['abs_positions'].size(0)
     n_atom_per_graph = x['abs_positions'].size(1)
     device = x['abs_positions'].device
-    adj_matrix, shift_matrix = get_adj_matrix(torch.randint(2, (batchsize * n_atom_per_graph) ** 2))  # TODO placeholder
+    # TODO placeholder
+    adj_matrix, shift_matrix = get_adj_matrix(torch.randint(2, (batchsize * n_atom_per_graph) ** 2, (1,)))
     # node features are int corresponding to atom type
-    node_attrs = torch.ones(batchsize, 1)  # TODO handle different type of atoms
+    node_attrs = torch.ones(batchsize * n_atom_per_graph, 1)  # TODO handle different type of atoms
     positions = x['abs_positions'].view(-1, x['abs_positions'].size(-1))  # [batchsize * natoms, spatial dimension]
     # pointer tensor that yields the first node index for each batch - this is a fixed tensor in our case
     ptr = torch.arange(0, n_atom_per_graph * batchsize + 1, step=n_atom_per_graph)  # 0, natoms, 2 * natoms, ...

--- a/crystal_diffusion/models/position_diffusion_lightning_model.py
+++ b/crystal_diffusion/models/position_diffusion_lightning_model.py
@@ -154,8 +154,10 @@ class PositionDiffusionLightningModel(pl.LightningModule):
         # The target is nabla log p_{t|0} (xt | x0): it is NOT the "score", but rather a "conditional" (on x0) score.
         target_normalized_conditional_scores = self._get_target_normalized_score(xt, x0, sigmas)
 
+        unit_cell = torch.diag_embed(batch["box"])  # from (batch, spatial_dim) to (batch, spatial_dim, spatial_dim)
+
         predicted_normalized_scores = self._get_predicted_normalized_score(
-            xt, noise_sample.time
+            xt, noise_sample.time, unit_cell
         )
 
         loss = torch.nn.functional.mse_loss(
@@ -201,7 +203,7 @@ class PositionDiffusionLightningModel(pl.LightningModule):
         return target_normalized_scores
 
     def _get_predicted_normalized_score(
-        self, noisy_relative_positions: torch.Tensor, time: torch.Tensor
+        self, noisy_relative_positions: torch.Tensor, time: torch.Tensor, unit_cell: torch.Tensor
     ) -> torch.Tensor:
         """Get predicted normalized score.
 
@@ -211,6 +213,8 @@ class PositionDiffusionLightningModel(pl.LightningModule):
             time : Noise times for the noisy relative positions. It is assumed that the inputs are consistent, ie,
                 the time values in this array correspond to the noise times used to create the noisy relative positions.
                 Tensor of dimensions [batch_size].
+            unit_cell: unit cell definition in Angstrom.
+                Tensor of dimensions [batch_size, spatial_dimension, spatial_dimension].
 
         Returns:
             predicted normalized score: sigma times predicted score, ie, sigma times S_theta(xt, t).
@@ -218,9 +222,11 @@ class PositionDiffusionLightningModel(pl.LightningModule):
         """
         pos_key = self.sigma_normalized_score_network.position_key
         time_key = self.sigma_normalized_score_network.timestep_key
+        unit_cell_key = self.sigma_normalized_score_network.unit_cell_key
         augmented_batch = {
             pos_key: noisy_relative_positions,
             time_key: time.reshape(-1, 1),
+            unit_cell_key: unit_cell,
         }
         predicted_normalized_scores = self.sigma_normalized_score_network(
             augmented_batch

--- a/crystal_diffusion/models/score_network.py
+++ b/crystal_diffusion/models/score_network.py
@@ -14,6 +14,7 @@ from torch import nn
 @dataclass(kw_only=True)
 class BaseScoreNetworkParameters:
     """Base Hyper-parameters for score networks."""
+
     spatial_dimension: int = 3  # the dimension of Euclidean space where atoms live.
 
 
@@ -23,6 +24,7 @@ class ScoreNetwork(torch.nn.Module):
     This base class defines the interface that all score networks should have
     in order to be easily interchangeable (ie, polymorphic).
     """
+
     position_key = "noisy_relative_positions"  # unitless positions in the lattice coordinate basis
     timestep_key = "time"
     unit_cell_key = "unit_cell"  # unit cell definition in Angstrom
@@ -90,17 +92,17 @@ class ScoreNetwork(torch.nn.Module):
         ).all(), "The times are expected to be normalized between 0 and 1."
 
         assert (
-                self.unit_cell_key in batch
+            self.unit_cell_key in batch
         ), f"The unit cell should be present in the batch dictionary with key '{self.unit_cell_key}'"
 
         unit_cell = batch[self.unit_cell_key]
         unit_cell_shape = unit_cell.shape
         assert (
-                unit_cell_shape[0] == batch_size
+            unit_cell_shape[0] == batch_size
         ), "the batch size dimension is inconsistent between positions and unit cell."
         assert (
-                len(unit_cell_shape) == 3 and unit_cell_shape[1] == self.spatial_dimension
-                and unit_cell_shape[2] == self.spatial_dimension
+            len(unit_cell_shape) == 3 and unit_cell_shape[1] == self.spatial_dimension
+            and unit_cell_shape[2] == self.spatial_dimension
         ), "The unit cell is expected to be in a tensor of shape [batch_size, spatial_dimension, spatial_dimension]."
 
     def forward(self, batch: Dict[AnyStr, torch.Tensor]) -> torch.Tensor:

--- a/crystal_diffusion/models/score_network.py
+++ b/crystal_diffusion/models/score_network.py
@@ -25,6 +25,7 @@ class ScoreNetwork(torch.nn.Module):
     """
     position_key = "noisy_relative_positions"  # unitless positions in the lattice coordinate basis
     timestep_key = "time"
+    unit_cell_key = "unit_cell"  # unit cell definition in Angstrom
 
     def __init__(self, hyper_params: BaseScoreNetworkParameters):
         """__init__.
@@ -87,6 +88,20 @@ class ScoreNetwork(torch.nn.Module):
         assert torch.logical_and(
             times >= 0.0, times <= 1.0
         ).all(), "The times are expected to be normalized between 0 and 1."
+
+        assert (
+                self.unit_cell_key in batch
+        ), f"The unit cell should be present in the batch dictionary with key '{self.unit_cell_key}'"
+
+        unit_cell = batch[self.unit_cell_key]
+        unit_cell_shape = unit_cell.shape
+        assert (
+                unit_cell_shape[0] == batch_size
+        ), "the batch size dimension is inconsistent between positions and unit cell."
+        assert (
+                len(unit_cell_shape) == 3 and unit_cell_shape[1] == self.spatial_dimension
+                and unit_cell_shape[2] == self.spatial_dimension
+        ), "The unit cell is expected to be in a tensor of shape [batch_size, spatial_dimension, spatial_dimension]."
 
     def forward(self, batch: Dict[AnyStr, torch.Tensor]) -> torch.Tensor:
         """Model forward.

--- a/crystal_diffusion/samplers/predictor_corrector_position_sampler.py
+++ b/crystal_diffusion/samplers/predictor_corrector_position_sampler.py
@@ -103,11 +103,13 @@ class AnnealedLangevinDynamicsSampler(PredictorCorrectorPositionSampler):
                  noise_parameters: NoiseParameters,
                  number_of_corrector_steps: int,
                  number_of_atoms: int,
+                 spatial_dimension: int,
                  sigma_normalized_score_network: ScoreNetwork,
                  ):
         """Init method."""
         super().__init__(number_of_discretization_steps=noise_parameters.total_time_steps,
-                         number_of_corrector_steps=number_of_corrector_steps)
+                         number_of_corrector_steps=number_of_corrector_steps,
+                         spatial_dimension=spatial_dimension)
         self.noise_parameters = noise_parameters
         sampler = ExplodingVarianceSampler(noise_parameters)
         self.noise, self.langevin_dynamics = sampler.get_all_sampling_parameters()

--- a/crystal_diffusion/samplers/predictor_corrector_position_sampler.py
+++ b/crystal_diffusion/samplers/predictor_corrector_position_sampler.py
@@ -136,7 +136,7 @@ class AnnealedLangevinDynamicsSampler(PredictorCorrectorPositionSampler):
         number_of_samples = x.shape[0]
 
         time_tensor = time * torch.ones(number_of_samples, 1).to(x)
-        augmented_batch = {pos_key: x, time_key: time_tensor,  unit_cell_key: unit_cell}
+        augmented_batch = {pos_key: x, time_key: time_tensor, unit_cell_key: unit_cell}
         with torch.no_grad():
             predicted_normalized_scores = self.sigma_normalized_score_network(augmented_batch)
 

--- a/crystal_diffusion/samplers/predictor_corrector_position_sampler.py
+++ b/crystal_diffusion/samplers/predictor_corrector_position_sampler.py
@@ -40,9 +40,6 @@ class PredictorCorrectorPositionSampler(ABC):
         """
         x_ip1 = map_positions_to_unit_cell(self.initialize(number_of_samples)).to(device)
 
-        if unit_cell.dim() == 2:  # no batchsize for unit cell, just repeat
-            unit_cell = unit_cell.unsqueeze(0).repeat(x_ip1.size(0), 1, 1)
-
         for i in tqdm(range(self.number_of_discretization_steps - 1, -1, -1)):
             x_i = map_positions_to_unit_cell(self.predictor_step(x_ip1, i + 1, unit_cell))
             for _ in range(self.number_of_corrector_steps):

--- a/crystal_diffusion/samplers/predictor_corrector_position_sampler.py
+++ b/crystal_diffusion/samplers/predictor_corrector_position_sampler.py
@@ -24,7 +24,7 @@ class PredictorCorrectorPositionSampler(ABC):
         self.number_of_discretization_steps = number_of_discretization_steps
         self.number_of_corrector_steps = number_of_corrector_steps
 
-    def sample(self, number_of_samples: int, device=torch.device) -> torch.Tensor:
+    def sample(self, number_of_samples: int, device=torch.device, unit_cell=torch.Tensor) -> torch.Tensor:
         """Sample.
 
         This method draws a sample using the PR sampler algorithm.
@@ -32,6 +32,8 @@ class PredictorCorrectorPositionSampler(ABC):
         Args:
             number_of_samples : number of samples to draw.
             device: device to use (cpu, cuda, etc.). Should match the PL model location.
+            unit_cell: unit cell definition in Angstrom.
+                Tensor of dimensions [batch_size, spatial_dimension, spatial_dimension]
 
         Returns:
             position samples: position samples.
@@ -39,9 +41,9 @@ class PredictorCorrectorPositionSampler(ABC):
         x_ip1 = map_positions_to_unit_cell(self.initialize(number_of_samples)).to(device)
         logger.info("Starting position sampling")
         for i in tqdm(range(self.number_of_discretization_steps - 1, -1, -1)):
-            x_i = map_positions_to_unit_cell(self.predictor_step(x_ip1, i + 1))
+            x_i = map_positions_to_unit_cell(self.predictor_step(x_ip1, i + 1, unit_cell))
             for _ in range(self.number_of_corrector_steps):
-                x_i = map_positions_to_unit_cell(self.corrector_step(x_i, i))
+                x_i = map_positions_to_unit_cell(self.corrector_step(x_i, i, unit_cell))
             x_ip1 = x_i
 
         return x_i
@@ -52,7 +54,7 @@ class PredictorCorrectorPositionSampler(ABC):
         pass
 
     @abstractmethod
-    def predictor_step(self, x_ip1: torch.Tensor, ip1: int) -> torch.Tensor:
+    def predictor_step(self, x_ip1: torch.Tensor, ip1: int, unit_cell: torch.Tensor) -> torch.Tensor:
         """Predictor step.
 
         It is assumed that there are N predictor steps, with index "i" running from N-1 to 0.
@@ -60,6 +62,7 @@ class PredictorCorrectorPositionSampler(ABC):
         Args:
             x_ip1 : sampled relative positions at step "i + 1".
             ip1 : index "i + 1"
+            unit_cell: sampled unit cell at time step "i + 1".
 
         Returns:
             x_i : sampled relative positions after the predictor step.
@@ -67,7 +70,7 @@ class PredictorCorrectorPositionSampler(ABC):
         pass
 
     @abstractmethod
-    def corrector_step(self, x_i: torch.Tensor, i: int) -> torch.Tensor:
+    def corrector_step(self, x_i: torch.Tensor, i: int, unit_cell: torch.Tensor) -> torch.Tensor:
         """Corrector step.
 
         It is assumed that there are N predictor steps, with index "i" running from N-1 to 0.
@@ -75,6 +78,7 @@ class PredictorCorrectorPositionSampler(ABC):
         Args:
             x_i : sampled relative positions at step "i".
             i : index "i" OF THE PREDICTOR STEP.
+            unit_cell: sampled unit cell at time step i.
 
         Returns:
             x_i_out : sampled relative positions after the corrector step.
@@ -114,34 +118,37 @@ class AnnealedLangevinDynamicsSampler(PredictorCorrectorPositionSampler):
     def _draw_gaussian_sample(self, number_of_samples):
         return torch.randn(number_of_samples, self.number_of_atoms, self.spatial_dimension)
 
-    def _get_sigma_normalized_scores(self, x: torch.Tensor, time: float) -> torch.Tensor:
+    def _get_sigma_normalized_scores(self, x: torch.Tensor, time: float, unit_cell: torch.Tensor) -> torch.Tensor:
         """Get sigma normalized scores.
 
         Args:
             x : relative positions, of shape [number_of_samples, number_of_atoms, spatial_dimension]
             time : time at which to evaluate the score
+            unit_cell: unit cell definition in Angstrom of shape [batch_size, spatial_dimension, spatial_dimension]
 
         Returns:
             sigma normalized score: sigma x Score(x, t).
         """
         pos_key = self.sigma_normalized_score_network.position_key
         time_key = self.sigma_normalized_score_network.timestep_key
+        unit_cell_key = self.sigma_normalized_score_network.unit_cell_key
 
         number_of_samples = x.shape[0]
 
         time_tensor = time * torch.ones(number_of_samples, 1).to(x)
-        augmented_batch = {pos_key: x, time_key: time_tensor}
+        augmented_batch = {pos_key: x, time_key: time_tensor,  unit_cell_key: unit_cell}
         with torch.no_grad():
             predicted_normalized_scores = self.sigma_normalized_score_network(augmented_batch)
 
         return predicted_normalized_scores
 
-    def predictor_step(self, x_i: torch.Tensor, index_i: int) -> torch.Tensor:
+    def predictor_step(self, x_i: torch.Tensor, index_i: int, unit_cell: torch.Tensor) -> torch.Tensor:
         """Predictor step.
 
         Args:
             x_i : sampled relative positions, at time step i.
             index_i : index of the time step.
+            unit_cell: sampled unit cell at time step i.
 
         Returns:
             x_im1 : sampled relative positions, at time step i - 1.
@@ -158,18 +165,19 @@ class AnnealedLangevinDynamicsSampler(PredictorCorrectorPositionSampler):
         g2_i = self.noise.g_squared[idx].to(x_i)
         sigma_i = self.noise.sigma[idx].to(x_i)
 
-        sigma_score_i = self._get_sigma_normalized_scores(x_i, t_i)
+        sigma_score_i = self._get_sigma_normalized_scores(x_i, t_i, unit_cell)
 
         x_im1 = x_i + g2_i / sigma_i * sigma_score_i + g_i * z
 
         return x_im1
 
-    def corrector_step(self, x_i: torch.Tensor, index_i: int) -> torch.Tensor:
+    def corrector_step(self, x_i: torch.Tensor, index_i: int, unit_cell: torch.Tensor) -> torch.Tensor:
         """Corrector Step.
 
         Args:
             x_i : sampled relative positions, at time step i.
             index_i : index of the time step.
+            unit_cell: sampled unit cell at time step i.
 
         Returns:
             corrected x_i : sampled relative positions, after corrector step.
@@ -194,7 +202,7 @@ class AnnealedLangevinDynamicsSampler(PredictorCorrectorPositionSampler):
             sigma_i = self.noise.sigma[idx].to(x_i)
             t_i = self.noise.time[idx].to(x_i)
 
-        sigma_score_i = self._get_sigma_normalized_scores(x_i, t_i)
+        sigma_score_i = self._get_sigma_normalized_scores(x_i, t_i, unit_cell)
 
         corrected_x_i = x_i + eps_i / sigma_i * sigma_score_i + sqrt_2eps_i * z
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ isort==5.13.2
 jupyter==1.0.0
 jinja2==3.1.2
 lammps
+mace-torch==0.3.4
 maml==2023.9.9
 monty==2024.2.2
 myst-parser==2.0.0
@@ -27,6 +28,7 @@ tensorboard==2.16.2
 tqdm==4.64.0
 torch==2.2.0
 torchvision>=0.17.0
+torch_geometric==2.5.3
 matplotlib==3.8.3
 rich==13.7.1
 deepdiff==7.0.1

--- a/tests/models/test_mace_utils.py
+++ b/tests/models/test_mace_utils.py
@@ -1,0 +1,97 @@
+import numpy as np
+import pytest
+import torch
+from mace.data import AtomicData, Configuration
+from mace.tools import get_atomic_number_table_from_zs
+from mace.tools.torch_geometric.dataloader import Collater
+
+from crystal_diffusion.models.mace_utils import input_to_mace
+
+
+@pytest.fixture()
+def n_atoms():
+    return 4
+
+
+@pytest.fixture()
+def spatial_dim():
+    return 3
+
+
+@pytest.fixture()
+def atomic_positions(n_atoms, spatial_dim):
+    # chain of atoms at x=0,1,2,3, y=z=0
+    pos = torch.zeros(n_atoms, spatial_dim)
+    pos[:, 0] += torch.arange(n_atoms)
+    return pos
+
+
+@pytest.fixture()
+def cell_size(n_atoms):
+    # get a cell much larger than spacing between atoms to not deal with periodicity
+    return 10 * n_atoms
+
+
+@pytest.fixture()
+def batchsize():
+    return 8
+
+
+@pytest.fixture()
+def mace_graph(cell_size, spatial_dim, atomic_positions, n_atoms, batchsize):
+    unit_cell = np.eye(spatial_dim) * cell_size  # box as a spatial_dim x spatial_dim array
+    atom_type = np.ones(n_atoms)
+    pbc = np.array([True] * spatial_dim)  # periodic boundary conditions
+    graph_config = Configuration(atomic_numbers=atom_type,
+                                 positions=atomic_positions.numpy(),
+                                 cell=unit_cell,
+                                 pbc=pbc)
+    z_table = get_atomic_number_table_from_zs([1])
+    # set the cutoff at 1.1 so the atoms form a simple chain 0 - 1 - 2 - 3
+    graph_data = AtomicData.from_config(graph_config, z_table=z_table, cutoff=1.1)
+    collate_fn = Collater(follow_batch=[None], exclude_keys=[None])
+    mace_batch = collate_fn([graph_data] * batchsize)
+    return mace_batch
+
+
+@pytest.fixture()
+def mocked_adjacency_matrix(n_atoms, batchsize):
+    # adjacency should be a (2, n_edge)
+    # we have a simple chain 0-1-2-3... in 1D, we can ignore complexities from periodicity and 3D
+    adj = torch.zeros(n_atoms, n_atoms)
+    for i in range(n_atoms):
+        if i < n_atoms - 1:
+            adj[i, i + 1] = 1  # 0 to 1, ... n-1 to n ; but not n to n+1
+        if i > 0:
+            adj[i, i - 1] = 1  # 1 to 0, 2 to 1... but not 0 to -1
+    adj = adj.unsqueeze(0).repeat(batchsize, 1, 1)
+    adj = adj.to_sparse().indices()
+    # adj contains (batch index, node index 1, node index 2)
+    # the batch index will create problems, so we need to remove it by reindexing the node
+    # for example, node 0 in the second graph should be considered as node index 0 + num_node
+    adj = adj[1:, :] + adj[0, :] * n_atoms  # now a 2 * num_edge tensor
+    return adj
+
+
+@pytest.fixture()
+def mocked_shift_matrix(n_atoms, batchsize, spatial_dim):
+    # chain structure: there are n_atoms - 1 links - which means 2 * (n_atoms - 1) edges from bidirectionality
+    # times batchsize to account for batching
+    return torch.zeros(2 * (n_atoms - 1) * batchsize, spatial_dim)
+
+
+def test_input_to_mace(mocker, batchsize, cell_size, spatial_dim, atomic_positions, mace_graph,
+                       mocked_adjacency_matrix, mocked_shift_matrix):
+    score_network_input = {}
+    score_network_input['abs_positions'] = atomic_positions.unsqueeze(0).repeat(batchsize, 1, 1)
+    mocker.patch("crystal_diffusion.models.mace_utils.get_adj_matrix",
+                 return_value=(mocked_adjacency_matrix, mocked_shift_matrix))
+    repeat_size = [batchsize] + [1] * spatial_dim
+    score_network_input['cell'] = torch.eye(spatial_dim).repeat(*repeat_size) * cell_size
+    crystal_diffusion_graph = input_to_mace(score_network_input, unit_cell_key='cell')
+
+    # check the features used in MACE as the same in both our homemade graph and the one native to mace library
+    for k in ['edge_index', 'node_attrs', 'positions', 'ptr', 'batch', 'cell']:
+        assert k in crystal_diffusion_graph.keys()
+        assert crystal_diffusion_graph[k].size() == mace_graph[k].size()
+        assert torch.equal(crystal_diffusion_graph[k], mace_graph[k])

--- a/tests/models/test_score_network.py
+++ b/tests/models/test_score_network.py
@@ -23,7 +23,9 @@ class TestScoreNetworkCheck:
         batch_size = 16
         positions = torch.rand(batch_size, 8, spatial_dimension)
         times = torch.rand(batch_size, 1)
-        return {ScoreNetwork.position_key: positions, ScoreNetwork.timestep_key: times}
+        unit_cell = torch.rand(batch_size, spatial_dimension, spatial_dimension)
+        return {ScoreNetwork.position_key: positions, ScoreNetwork.timestep_key: times,
+                ScoreNetwork.unit_cell_key: unit_cell}
 
     @pytest.fixture()
     def bad_batch(self, good_batch, problem):
@@ -94,7 +96,9 @@ class TestMLPScoreNetwork:
     def good_batch(self, batch_size, number_of_atoms, spatial_dimension):
         positions = torch.rand(batch_size, number_of_atoms, spatial_dimension)
         times = torch.rand(batch_size, 1)
-        return {ScoreNetwork.position_key: positions, ScoreNetwork.timestep_key: times}
+        unit_cell = torch.rand(batch_size, spatial_dimension, spatial_dimension)
+        return {ScoreNetwork.position_key: positions, ScoreNetwork.timestep_key: times,
+                ScoreNetwork.unit_cell_key: unit_cell}
 
     @pytest.fixture()
     def bad_batch(self, batch_size, number_of_atoms, spatial_dimension):

--- a/tests/samplers/test_predictor_corrector_position_sampler.py
+++ b/tests/samplers/test_predictor_corrector_position_sampler.py
@@ -51,7 +51,7 @@ class TestPredictorCorrectorPositionSampler:
 
     @pytest.fixture
     def sampler(
-        self, number_of_discretization_steps, number_of_corrector_steps, initial_sample
+        self, number_of_discretization_steps, number_of_corrector_steps, spatial_dimension, initial_sample
     ):
         sampler = FakePCSampler(
             number_of_discretization_steps, number_of_corrector_steps, spatial_dimension, initial_sample

--- a/tests/samplers/test_predictor_corrector_position_sampler.py
+++ b/tests/samplers/test_predictor_corrector_position_sampler.py
@@ -26,10 +26,10 @@ class FakePCSampler(PredictorCorrectorPositionSampler):
     def initialize(self, number_of_samples: int):
         return self.initial_sample
 
-    def predictor_step(self, x_ip1: torch.Tensor, ip1: int) -> torch.Tensor:
+    def predictor_step(self, x_ip1: torch.Tensor, ip1: int, unit_cell: torch.Tensor) -> torch.Tensor:
         return 1.2 * x_ip1 + 3.4 + ip1 / 111.0
 
-    def corrector_step(self, x_i: torch.Tensor, i: int) -> torch.Tensor:
+    def corrector_step(self, x_i: torch.Tensor, i: int, unit_cell: torch.Tensor) -> torch.Tensor:
         return 0.56 * x_i + 7.89 + i / 117.0
 
 
@@ -38,6 +38,7 @@ class FakePCSampler(PredictorCorrectorPositionSampler):
 @pytest.mark.parametrize("spatial_dimension", [2, 3])
 @pytest.mark.parametrize("number_of_discretization_steps", [1, 5, 10])
 @pytest.mark.parametrize("number_of_corrector_steps", [0, 1, 2])
+@pytest.mark.parametrize("unit_cell_size", [10])
 class TestPredictorCorrectorPositionSampler:
     @pytest.fixture(scope="class", autouse=True)
     def set_random_seed(self):
@@ -56,6 +57,10 @@ class TestPredictorCorrectorPositionSampler:
         )
         return sampler
 
+    @pytest.fixture()
+    def unit_cell_sample(self, unit_cell_size, spatial_dimension, number_of_samples):
+        return torch.diag(torch.Tensor([unit_cell_size] * spatial_dimension)).repeat(number_of_samples, 1, 1)
+
     @pytest.fixture
     def expected_samples(
         self,
@@ -63,6 +68,7 @@ class TestPredictorCorrectorPositionSampler:
         initial_sample,
         number_of_discretization_steps,
         number_of_corrector_steps,
+        unit_cell_sample,
     ):
         list_i = list(range(number_of_discretization_steps))
         list_i.reverse()
@@ -71,14 +77,14 @@ class TestPredictorCorrectorPositionSampler:
         noisy_sample = map_positions_to_unit_cell(initial_sample)
         x_ip1 = noisy_sample
         for i in list_i:
-            xi = map_positions_to_unit_cell(sampler.predictor_step(x_ip1, i + 1))
+            xi = map_positions_to_unit_cell(sampler.predictor_step(x_ip1, i + 1, unit_cell_sample))
             for _ in list_j:
-                xi = map_positions_to_unit_cell(sampler.corrector_step(xi, i))
+                xi = map_positions_to_unit_cell(sampler.corrector_step(xi, i, unit_cell_sample))
             x_ip1 = xi
         return xi
 
-    def test_sample(self, sampler, number_of_samples, expected_samples):
-        computed_samples = sampler.sample(number_of_samples, torch.device('cpu'))
+    def test_sample(self, sampler, number_of_samples, expected_samples, unit_cell_sample):
+        computed_samples = sampler.sample(number_of_samples, torch.device('cpu'), unit_cell_sample)
         torch.testing.assert_allclose(expected_samples, computed_samples)
 
 
@@ -92,6 +98,7 @@ class TestPredictorCorrectorPositionSampler:
 @pytest.mark.parametrize("sigma_min", [0.15])
 @pytest.mark.parametrize("corrector_step_epsilon", [0.25])
 @pytest.mark.parametrize("number_of_samples", [8])
+@pytest.mark.parametrize("unit_cell_size", [10])
 class TestAnnealedLangevinDynamics:
     @pytest.fixture()
     def sigma_normalized_score_network(
@@ -127,15 +134,20 @@ class TestAnnealedLangevinDynamics:
 
         return sampler
 
-    def test_smoke_sample(self, pc_sampler, number_of_samples):
+    @pytest.fixture()
+    def unit_cell_sample(self, unit_cell_size, spatial_dimension, number_of_samples):
+        return torch.diag(torch.Tensor([unit_cell_size] * spatial_dimension)).repeat(number_of_samples, 1, 1)
+
+    def test_smoke_sample(self, pc_sampler, number_of_samples, unit_cell_sample):
         # Just a smoke test that we can sample without crashing.
-        pc_sampler.sample(number_of_samples, torch.device('cpu'))
+        pc_sampler.sample(number_of_samples, torch.device('cpu'), unit_cell_sample)
 
     @pytest.fixture()
     def x_i(self, number_of_samples, number_of_atoms, spatial_dimension):
         return map_positions_to_unit_cell(torch.rand(number_of_samples, number_of_atoms, spatial_dimension))
 
-    def test_predictor_step(self, mocker, pc_sampler, noise_parameters, x_i, total_time_steps, number_of_samples):
+    def test_predictor_step(self, mocker, pc_sampler, noise_parameters, x_i, total_time_steps, number_of_samples,
+                            unit_cell_sample):
 
         sampler = ExplodingVarianceSampler(noise_parameters)
         noise, _ = sampler.get_all_sampling_parameters()
@@ -147,7 +159,7 @@ class TestAnnealedLangevinDynamics:
         mocker.patch.object(pc_sampler, "_draw_gaussian_sample", return_value=z)
 
         for index_i in range(1, total_time_steps + 1):
-            computed_sample = pc_sampler.predictor_step(x_i, index_i)
+            computed_sample = pc_sampler.predictor_step(x_i, index_i, unit_cell_sample)
 
             sigma_i = list_sigma[index_i - 1]
             t_i = list_time[index_i - 1]
@@ -158,13 +170,14 @@ class TestAnnealedLangevinDynamics:
 
             g2 = sigma_i**2 - sigma_im1**2
 
-            s_i = pc_sampler._get_sigma_normalized_scores(x_i, t_i) / sigma_i
+            s_i = pc_sampler._get_sigma_normalized_scores(x_i, t_i, unit_cell_sample) / sigma_i
 
             expected_sample = x_i + g2 * s_i + torch.sqrt(g2) * z
 
             torch.testing.assert_allclose(computed_sample, expected_sample)
 
-    def test_corrector_step(self, mocker, pc_sampler, noise_parameters, x_i, total_time_steps, number_of_samples):
+    def test_corrector_step(self, mocker, pc_sampler, noise_parameters, x_i, total_time_steps, number_of_samples,
+                            unit_cell_sample):
 
         sampler = ExplodingVarianceSampler(noise_parameters)
         noise, _ = sampler.get_all_sampling_parameters()
@@ -178,7 +191,7 @@ class TestAnnealedLangevinDynamics:
         mocker.patch.object(pc_sampler, "_draw_gaussian_sample", return_value=z)
 
         for index_i in range(0, total_time_steps):
-            computed_sample = pc_sampler.corrector_step(x_i, index_i)
+            computed_sample = pc_sampler.corrector_step(x_i, index_i, unit_cell_sample)
 
             if index_i == 0:
                 sigma_i = sigma_min
@@ -189,7 +202,7 @@ class TestAnnealedLangevinDynamics:
 
             eps_i = 0.5 * epsilon * sigma_i**2 / sigma_1**2
 
-            s_i = pc_sampler._get_sigma_normalized_scores(x_i, t_i) / sigma_i
+            s_i = pc_sampler._get_sigma_normalized_scores(x_i, t_i, unit_cell_sample) / sigma_i
 
             expected_sample = x_i + eps_i * s_i + torch.sqrt(2. * eps_i) * z
 

--- a/tests/samplers/test_predictor_corrector_position_sampler.py
+++ b/tests/samplers/test_predictor_corrector_position_sampler.py
@@ -86,7 +86,7 @@ class TestPredictorCorrectorPositionSampler:
 
     def test_sample(self, sampler, number_of_samples, expected_samples, unit_cell_sample):
         computed_samples = sampler.sample(number_of_samples, torch.device('cpu'), unit_cell_sample)
-        torch.testing.assert_allclose(expected_samples, computed_samples)
+        torch.testing.assert_close(expected_samples, computed_samples)
 
 
 @pytest.mark.parametrize("total_time_steps", [1, 5, 10])
@@ -175,7 +175,7 @@ class TestAnnealedLangevinDynamics:
 
             expected_sample = x_i + g2 * s_i + torch.sqrt(g2) * z
 
-            torch.testing.assert_allclose(computed_sample, expected_sample)
+            torch.testing.assert_close(computed_sample, expected_sample)
 
     def test_corrector_step(self, mocker, pc_sampler, noise_parameters, x_i, total_time_steps, number_of_samples,
                             unit_cell_sample):
@@ -207,4 +207,4 @@ class TestAnnealedLangevinDynamics:
 
             expected_sample = x_i + eps_i * s_i + torch.sqrt(2. * eps_i) * z
 
-            torch.testing.assert_allclose(computed_sample, expected_sample)
+            torch.testing.assert_close(computed_sample, expected_sample)

--- a/tests/samplers/test_predictor_corrector_position_sampler.py
+++ b/tests/samplers/test_predictor_corrector_position_sampler.py
@@ -18,9 +18,10 @@ class FakePCSampler(PredictorCorrectorPositionSampler):
         self,
         number_of_discretization_steps: int,
         number_of_corrector_steps: int,
+        spatial_dimension: int,
         initial_sample: torch.Tensor,
     ):
-        super().__init__(number_of_discretization_steps, number_of_corrector_steps)
+        super().__init__(number_of_discretization_steps, number_of_corrector_steps, spatial_dimension)
         self.initial_sample = initial_sample
 
     def initialize(self, number_of_samples: int):
@@ -53,7 +54,7 @@ class TestPredictorCorrectorPositionSampler:
         self, number_of_discretization_steps, number_of_corrector_steps, initial_sample
     ):
         sampler = FakePCSampler(
-            number_of_discretization_steps, number_of_corrector_steps, initial_sample
+            number_of_discretization_steps, number_of_corrector_steps, spatial_dimension, initial_sample
         )
         return sampler
 


### PR DESCRIPTION
This new function takes the score network input and creates a graph usable by MACE. 
I added the mace library and pytorch-geometric as requirements.

I used a placeholder for the adjacency matrix - this is developed in another branch.
I had to add the unit_cell as a passed arguments to the score network input - along fixing the related unit tests.

This method is fully GPU friendly. It might be a bit slow, but this is beyond the scope of this project to accelerate pytorch-geometric :)