### PR TITLE
Testing adjacency matrix

### DIFF
--- a/crystal_diffusion/models/mace_utils.py
+++ b/crystal_diffusion/models/mace_utils.py
@@ -61,7 +61,6 @@ def input_to_mace(x: Dict[AnyStr, torch.Tensor], unit_cell_key: str, radial_cuto
     cell = x[unit_cell_key]  # batch, spatial_dimension, spatial_dimension
     n_atom_per_graph = x['abs_positions'].size(1)
     device = x['abs_positions'].device
-    # TODO : make the radial cut-off available here
     adj_matrix, shift_matrix, batch_tensor = get_adj_matrix(positions=x['abs_positions'],
                                                             basis_vectors=cell,
                                                             radial_cutoff=radial_cutoff)

--- a/crystal_diffusion/models/mace_utils.py
+++ b/crystal_diffusion/models/mace_utils.py
@@ -41,32 +41,35 @@ def get_adj_matrix(positions: torch.Tensor,
                                                                                  number_of_edges,
                                                                                  number_of_atoms)
     shifts = adjacency_info.shifts
-    batch_indices = adjacency_info.batch_indices
+    batch_indices = adjacency_info.node_batch_indices
 
     return shifted_adjacency_matrix, shifts, batch_indices
 
 
-def input_to_mace(x: Dict[AnyStr, torch.Tensor], unit_cell_key: str) -> Data:
+def input_to_mace(x: Dict[AnyStr, torch.Tensor], unit_cell_key: str, radial_cutoff: float) -> Data:
     """Convert score network input to MACE input.
 
     Args:
         x: score network input dictionary
         unit_cell_key: keyword argument to find the cell definition
+        radial_cutoff : largest distance between neighbors.
 
     Returns:
         pytorch-geometric graph data compatible with MACE forward
     """
-    batchsize = x['abs_positions'].size(0)
+    batch_size = x['abs_positions'].size(0)
     cell = x[unit_cell_key]  # batch, spatial_dimension, spatial_dimension
     n_atom_per_graph = x['abs_positions'].size(1)
     device = x['abs_positions'].device
     # TODO : make the radial cut-off available here
-    adj_matrix, shift_matrix, batch_tensor = get_adj_matrix(positions=x['abs_positions'], basis_vectors=cell)
+    adj_matrix, shift_matrix, batch_tensor = get_adj_matrix(positions=x['abs_positions'],
+                                                            basis_vectors=cell,
+                                                            radial_cutoff=radial_cutoff)
     # node features are int corresponding to atom type
-    node_attrs = torch.ones(batchsize * n_atom_per_graph, 1)  # TODO handle different type of atoms
+    node_attrs = torch.ones(batch_size * n_atom_per_graph, 1)  # TODO handle different type of atoms
     positions = x['abs_positions'].view(-1, x['abs_positions'].size(-1))  # [batchsize * natoms, spatial dimension]
     # pointer tensor that yields the first node index for each batch - this is a fixed tensor in our case
-    ptr = torch.arange(0, n_atom_per_graph * batchsize + 1, step=n_atom_per_graph)  # 0, natoms, 2 * natoms, ...
+    ptr = torch.arange(0, n_atom_per_graph * batch_size + 1, step=n_atom_per_graph)  # 0, natoms, 2 * natoms, ...
 
     cell = cell.view(-1, cell.size(-1))  # batch * spatial_dimension, spatial_dimension
     # create the pytorch-geometric graph

--- a/tests/models/test_mace_utils.py
+++ b/tests/models/test_mace_utils.py
@@ -6,95 +6,147 @@ from mace.tools import get_atomic_number_table_from_zs
 from mace.tools.torch_geometric.dataloader import Collater
 
 from crystal_diffusion.models.mace_utils import input_to_mace
+from crystal_diffusion.utils.neighbors import _get_positions_from_coordinates
+from tests.fake_data_utils import find_aligning_permutation
 
 
-@pytest.fixture()
-def n_atoms():
-    return 4
+class TestInputToMaceChain:
+
+    @pytest.fixture()
+    def spatial_dim(self):
+        return 3
+
+    @pytest.fixture()
+    def batch_size(self):
+        return 8
+
+    @pytest.fixture()
+    def n_atoms(self):
+        return 4
+
+    @pytest.fixture()
+    def atomic_positions(self, n_atoms, spatial_dim):
+        # chain of atoms at x=0,1,2,3, y=z=0
+        pos = torch.zeros(n_atoms, spatial_dim)
+        pos[:, 0] += torch.arange(n_atoms)
+        return pos
+
+    @pytest.fixture()
+    def cell_size(self, n_atoms):
+        # get a cell much larger than spacing between atoms to not deal with periodicity
+        return 10 * n_atoms
+
+    @pytest.fixture()
+    def radial_cutoff(self):
+        # set the cutoff at 1.1 so the atoms form a simple chain 0 - 1 - 2 - 3
+        return 1.1
+
+    @pytest.fixture()
+    def mace_graph(self, cell_size, spatial_dim, atomic_positions, n_atoms, batch_size, radial_cutoff):
+        unit_cell = np.eye(spatial_dim) * cell_size  # box as a spatial_dim x spatial_dim array
+        atom_type = np.ones(n_atoms)
+        pbc = np.array([True] * spatial_dim)  # periodic boundary conditions
+        graph_config = Configuration(atomic_numbers=atom_type,
+                                     positions=atomic_positions.numpy(),
+                                     cell=unit_cell,
+                                     pbc=pbc)
+        z_table = get_atomic_number_table_from_zs([1])
+        graph_data = AtomicData.from_config(graph_config, z_table=z_table, cutoff=radial_cutoff)
+        collate_fn = Collater(follow_batch=[None], exclude_keys=[None])
+        mace_batch = collate_fn([graph_data] * batch_size)
+        return mace_batch
+
+    @pytest.fixture()
+    def score_network_input(self, batch_size, spatial_dim, cell_size, atomic_positions):
+        score_network_input = dict(abs_positions=atomic_positions.unsqueeze(0).repeat(batch_size, 1, 1),
+                                   cell=torch.eye(spatial_dim).repeat(batch_size, 1, 1) * cell_size)
+        return score_network_input
+
+    def test_input_to_mace(self, score_network_input, radial_cutoff, mace_graph):
+        crystal_diffusion_graph = input_to_mace(score_network_input,
+                                                unit_cell_key='cell',
+                                                radial_cutoff=radial_cutoff)
+
+        # check the features used in MACE as the same in both our homemade graph and the one native to mace library
+        for k in ['edge_index', 'node_attrs', 'positions', 'ptr', 'batch', 'cell']:
+            assert k in crystal_diffusion_graph.keys()
+            assert crystal_diffusion_graph[k].size() == mace_graph[k].size()
+            assert torch.equal(crystal_diffusion_graph[k], mace_graph[k])
 
 
-@pytest.fixture()
-def spatial_dim():
-    return 3
+class TestInputToMaceRandom(TestInputToMaceChain):
+    @pytest.fixture(scope="class", autouse=True)
+    def set_seed(self):
+        """Set the random seed."""
+        torch.manual_seed(2345234234)
 
+    @pytest.fixture()
+    def n_atoms(self):
+        return 16
 
-@pytest.fixture()
-def atomic_positions(n_atoms, spatial_dim):
-    # chain of atoms at x=0,1,2,3, y=z=0
-    pos = torch.zeros(n_atoms, spatial_dim)
-    pos[:, 0] += torch.arange(n_atoms)
-    return pos
+    @pytest.fixture
+    def basis_vectors(self, batch_size):
+        # orthogonal boxes with dimensions between 5 and 10.
+        orthogonal_boxes = torch.stack([torch.diag(5. + 5. * torch.rand(3)) for _ in range(batch_size)])
+        # add a bit of noise to make the vectors not quite orthogonal
+        basis_vectors = orthogonal_boxes + 0.1 * torch.randn(batch_size, 3, 3)
+        return basis_vectors
 
+    @pytest.fixture
+    def positions(self, batch_size, n_atoms, spatial_dim, basis_vectors):
+        relative_coordinates = torch.rand(batch_size, n_atoms, spatial_dim)
+        positions = _get_positions_from_coordinates(relative_coordinates, basis_vectors)
+        return positions
 
-@pytest.fixture()
-def cell_size(n_atoms):
-    # get a cell much larger than spacing between atoms to not deal with periodicity
-    return 10 * n_atoms
+    @pytest.fixture()
+    def mace_graph(self, basis_vectors, positions, spatial_dim, n_atoms, radial_cutoff):
+        pbc = np.array([True] * spatial_dim)  # periodic boundary conditions
+        atom_type = np.ones(n_atoms)
 
+        list_graphs = []
+        for unit_cell, atomic_positions in zip(basis_vectors, positions):
+            graph_config = Configuration(atomic_numbers=atom_type,
+                                         positions=atomic_positions.numpy(),
+                                         cell=unit_cell,
+                                         pbc=pbc)
+            z_table = get_atomic_number_table_from_zs([1])
+            graph_data = AtomicData.from_config(graph_config, z_table=z_table, cutoff=radial_cutoff)
+            list_graphs.append(graph_data)
 
-@pytest.fixture()
-def batch_size():
-    return 8
+        collate_fn = Collater(follow_batch=[None], exclude_keys=[None])
+        mace_batch = collate_fn(list_graphs)
+        return mace_batch
 
+    @pytest.fixture()
+    def score_network_input(self, positions, basis_vectors):
+        score_network_input = dict(abs_positions=positions, cell=basis_vectors)
+        return score_network_input
 
-@pytest.fixture()
-def mace_graph(cell_size, spatial_dim, atomic_positions, n_atoms, batch_size):
-    unit_cell = np.eye(spatial_dim) * cell_size  # box as a spatial_dim x spatial_dim array
-    atom_type = np.ones(n_atoms)
-    pbc = np.array([True] * spatial_dim)  # periodic boundary conditions
-    graph_config = Configuration(atomic_numbers=atom_type,
-                                 positions=atomic_positions.numpy(),
-                                 cell=unit_cell,
-                                 pbc=pbc)
-    z_table = get_atomic_number_table_from_zs([1])
-    # set the cutoff at 1.1 so the atoms form a simple chain 0 - 1 - 2 - 3
-    graph_data = AtomicData.from_config(graph_config, z_table=z_table, cutoff=1.1)
-    collate_fn = Collater(follow_batch=[None], exclude_keys=[None])
-    mace_batch = collate_fn([graph_data] * batch_size)
-    return mace_batch
+    @pytest.mark.parametrize("radial_cutoff", [1.1, 2.2, 4.4])
+    def test_input_to_mace(self, score_network_input, radial_cutoff, mace_graph):
+        computed_mace_graph = input_to_mace(score_network_input,
+                                            unit_cell_key='cell',
+                                            radial_cutoff=radial_cutoff)
 
+        for feature_name in ['node_attrs', 'positions', 'ptr', 'batch', 'cell']:
+            torch.testing.assert_close(mace_graph[feature_name], computed_mace_graph[feature_name])
 
-@pytest.fixture()
-def mocked_adjacency_matrix(n_atoms, batch_size):
-    # adjacency should be a (2, n_edge)
-    # we have a simple chain 0-1-2-3... in 1D, we can ignore complexities from periodicity and 3D
-    adj = torch.zeros(n_atoms, n_atoms)
-    for i in range(n_atoms):
-        if i < n_atoms - 1:
-            adj[i, i + 1] = 1  # 0 to 1, ... n-1 to n ; but not n to n+1
-        if i > 0:
-            adj[i, i - 1] = 1  # 1 to 0, 2 to 1... but not 0 to -1
-    adj = adj.unsqueeze(0).repeat(batch_size, 1, 1)
-    adj = adj.to_sparse().indices()
-    # adj contains (batch index, node index 1, node index 2)
-    # the batch index will create problems, so we need to remove it by reindexing the node
-    # for example, node 0 in the second graph should be considered as node index 0 + num_node
-    adj = adj[1:, :] + adj[0, :] * n_atoms  # now a 2 * num_edge tensor
-    return adj
+        # The EDGES might not be in the same order. Compute permutations of edges
 
+        expected_src_idx = mace_graph['edge_index'][0, :]
+        expected_dst_idx = mace_graph['edge_index'][1, :]
 
-@pytest.fixture()
-def mocked_shift_matrix(n_atoms, batch_size, spatial_dim):
-    # chain structure: there are n_atoms - 1 links - which means 2 * (n_atoms - 1) edges from bidirectionality
-    # times batchsize to account for batching
-    return torch.zeros(2 * (n_atoms - 1) * batch_size, spatial_dim)
+        expected_displacements = (mace_graph['positions'][expected_dst_idx] + mace_graph['shifts']
+                                  - mace_graph['positions'][expected_src_idx])
 
+        computed_src_idx = computed_mace_graph['edge_index'][0, :]
+        computed_dst_idx = computed_mace_graph['edge_index'][1, :]
+        computed_displacements = (computed_mace_graph['positions'][computed_dst_idx] + computed_mace_graph['shifts']
+                                  - computed_mace_graph['positions'][computed_src_idx])
 
-def test_input_to_mace(mocker, batch_size, cell_size, spatial_dim, atomic_positions, mace_graph,
-                       mocked_adjacency_matrix, mocked_shift_matrix, n_atoms):
-    score_network_input = {}
-    score_network_input['abs_positions'] = atomic_positions.unsqueeze(0).repeat(batch_size, 1, 1)
+        # The edge order can be different between the two graphs
+        edge_permutation_indices = find_aligning_permutation(expected_displacements, computed_displacements)
 
-    batch_tensor = torch.repeat_interleave(torch.arange(0, batch_size), n_atoms)
-
-    mocker.patch("crystal_diffusion.models.mace_utils.get_adj_matrix",
-                 return_value=(mocked_adjacency_matrix, mocked_shift_matrix, batch_tensor))
-    repeat_size = [batch_size] + [1] * spatial_dim
-    score_network_input['cell'] = torch.eye(spatial_dim).repeat(*repeat_size) * cell_size
-    crystal_diffusion_graph = input_to_mace(score_network_input, unit_cell_key='cell')
-
-    # check the features used in MACE as the same in both our homemade graph and the one native to mace library
-    for k in ['edge_index', 'node_attrs', 'positions', 'ptr', 'batch', 'cell']:
-        assert k in crystal_diffusion_graph.keys()
-        assert crystal_diffusion_graph[k].size() == mace_graph[k].size()
-        assert torch.equal(crystal_diffusion_graph[k], mace_graph[k])
+        torch.testing.assert_close(computed_mace_graph['shifts'][edge_permutation_indices], mace_graph['shifts'])
+        torch.testing.assert_close(computed_mace_graph['edge_index'][:, edge_permutation_indices],
+                                   mace_graph['edge_index'])

--- a/tests/utils/test_neighbors.py
+++ b/tests/utils/test_neighbors.py
@@ -6,12 +6,10 @@ import torch
 from pymatgen.core import Lattice, Structure
 
 from crystal_diffusion.utils.neighbors import (
-    INDEX_PADDING_VALUE, POSITION_PADDING_VALUE,
-    _get_positions_from_coordinates, _get_relative_coordinates_lattice_vectors,
-    _get_shifted_positions, _get_shortest_distance_that_crosses_unit_cell,
-    _get_vectors_from_multiple_indices,
-    convert_adjacency_info_into_batched_and_padded_data,
-    get_periodic_adjacency_information,
+    AdjacencyInfo, _get_positions_from_coordinates,
+    _get_relative_coordinates_lattice_vectors, _get_shifted_positions,
+    _get_shortest_distance_that_crosses_unit_cell,
+    _get_vectors_from_multiple_indices, get_periodic_adjacency_information,
     shift_adjacency_matrix_indices_for_graph_batching)
 from tests.fake_data_utils import find_aligning_permutation
 
@@ -69,7 +67,6 @@ def structures(basis_vectors, relative_coordinates):
     for basis, coordinates in zip(basis_vectors, relative_coordinates):
         number_of_atoms = coordinates.shape[0]
         species = number_of_atoms * ["Si"]  # this is a dummy variable. It doesn't matter what the atom types are...
-        # TODO
         lattice = Lattice(matrix=basis.cpu().numpy(), pbc=(True, True, True))
 
         structure = Structure(lattice=lattice,
@@ -114,101 +111,65 @@ def expected_neighbors(structures, radial_cutoff):
 
 
 @pytest.fixture
-def expected_neighbor_indices_and_displacements(expected_neighbors):
+def expected_adjacency_info(structures, expected_neighbors):
+    node_batch_indices = []
+    edge_batch_indices = []
+    shifts = []
+    adj_matrix = []
+    number_of_edges = []
+    for batch_index, (structure, list_neighbors) in enumerate(zip(structures, expected_neighbors)):
+        number_of_atoms = len(structure)
+        batch_node_batch_indices = torch.tensor(number_of_atoms * [batch_index], dtype=torch.long)
+        node_batch_indices.append(batch_node_batch_indices)
 
-    list_source_indices = []
-    list_dest_indices = []
-    list_displacements = []
-    list_shifts = []
-    for list_neighbors in expected_neighbors:
+        batch_shifts = torch.stack([torch.from_numpy(neigh.shift) for neigh in list_neighbors])
+        shifts.append(batch_shifts)
+
         source_indices = torch.tensor([neigh.source_index for neigh in list_neighbors])
-        list_source_indices.append(source_indices)
-
         dest_indices = torch.tensor([neigh.destination_index for neigh in list_neighbors])
-        list_dest_indices.append(dest_indices)
+        batch_adj_matrix = torch.stack([source_indices, dest_indices])
+        adj_matrix.append(batch_adj_matrix)
 
-        displacements = torch.stack([torch.from_numpy(neigh.displacement) for neigh in list_neighbors])
-        list_displacements.append(displacements)
+        number_of_edges.append(len(source_indices))
 
-        shifts = torch.stack([torch.from_numpy(neigh.shift) for neigh in list_neighbors])
-        list_shifts.append(shifts)
+        batch_edge_batch_indices = torch.tensor(len(source_indices) * [batch_index], dtype=torch.long)
+        edge_batch_indices.append(batch_edge_batch_indices)
 
-    expected_source_indices = torch.nn.utils.rnn.pad_sequence(list_source_indices,
-                                                              batch_first=True,
-                                                              padding_value=INDEX_PADDING_VALUE)
-
-    expected_destination_indices = torch.nn.utils.rnn.pad_sequence(list_dest_indices,
-                                                                   batch_first=True,
-                                                                   padding_value=INDEX_PADDING_VALUE)
-
-    expected_displacements = torch.nn.utils.rnn.pad_sequence(list_displacements,
-                                                             batch_first=True,
-                                                             padding_value=POSITION_PADDING_VALUE)
-
-    expected_shifts = torch.nn.utils.rnn.pad_sequence(list_shifts,
-                                                      batch_first=True,
-                                                      padding_value=POSITION_PADDING_VALUE)
-
-    return expected_source_indices, expected_destination_indices, expected_displacements, expected_shifts
+    return AdjacencyInfo(adjacency_matrix=torch.cat(adj_matrix, dim=1),
+                         shifts=torch.cat(shifts, dim=0),
+                         node_batch_indices=torch.cat(node_batch_indices),
+                         edge_batch_indices=torch.cat(edge_batch_indices),
+                         number_of_edges=torch.tensor(number_of_edges))
 
 
-# This test might be slow because KeOps needs to compile some stuff...
-@pytest.mark.parametrize("radial_cutoff", [3.3])
-def test_get_periodic_neighbour_indices_and_displacements(basis_vectors, positions, radial_cutoff,
-                                                          expected_neighbor_indices_and_displacements):
+@pytest.mark.parametrize("radial_cutoff", [1.1, 2.2, 3.3])
+def test_get_periodic_adjacency_information(basis_vectors, positions, radial_cutoff,
+                                            batch_size, expected_adjacency_info):
+    computed_adjacency_info = get_periodic_adjacency_information(positions, basis_vectors, radial_cutoff)
 
-    # This is what we are really trying to test
-    adjacency_info = get_periodic_adjacency_information(positions, basis_vectors, radial_cutoff)
+    torch.testing.assert_close(expected_adjacency_info.number_of_edges, computed_adjacency_info.number_of_edges)
+    torch.testing.assert_close(expected_adjacency_info.node_batch_indices, computed_adjacency_info.node_batch_indices)
+    torch.testing.assert_close(expected_adjacency_info.edge_batch_indices, computed_adjacency_info.edge_batch_indices)
 
-    # It is convenient to transform the data for test purposes.
-    computed_src_idx, computed_dst_idx, computed_displacements, computed_shifts = (
-        convert_adjacency_info_into_batched_and_padded_data(adjacency_info, positions))
-
-    (expected_src_idx, expected_dst_idx,
-     expected_displacements, expected_shifts) = expected_neighbor_indices_and_displacements
-
-    batch_size, max_edges, spatial_dimension = expected_displacements.shape
-
-    assert computed_src_idx.shape == (batch_size, max_edges)
-    assert computed_dst_idx.shape == (batch_size, max_edges)
-    assert computed_displacements.shape == (batch_size, max_edges, spatial_dimension)
-    assert computed_shifts.shape == (batch_size, max_edges, spatial_dimension)
-
-    # Validate that the padding is the same in both computed and expected arrays
-    torch.testing.assert_close(torch.isnan(computed_displacements), torch.isnan(expected_displacements))
-    torch.testing.assert_close(expected_src_idx == INDEX_PADDING_VALUE, computed_src_idx == INDEX_PADDING_VALUE)
-    torch.testing.assert_close(expected_dst_idx == INDEX_PADDING_VALUE, computed_dst_idx == INDEX_PADDING_VALUE)
-
-    # The edges might not be in the same order. Check permutations
+    # The edges might not be in the same order; build the corresponding permutation.
     for batch_idx in range(batch_size):
+        expected_mask = expected_adjacency_info.edge_batch_indices == batch_idx
+        expected_src_idx, expected_dst_idx = expected_adjacency_info.adjacency_matrix[:, expected_mask]
+        expected_shifts = expected_adjacency_info.shifts[expected_mask, :]
+        expected_displacements = (positions[batch_idx, expected_dst_idx] + expected_shifts
+                                  - positions[batch_idx, expected_src_idx])
 
-        batch_expected_src_idx = expected_src_idx[batch_idx]
-        valid_count = (batch_expected_src_idx != INDEX_PADDING_VALUE).sum()
+        computed_mask = computed_adjacency_info.edge_batch_indices == batch_idx
+        computed_src_idx, computed_dst_idx = computed_adjacency_info.adjacency_matrix[:, computed_mask]
+        computed_shifts = computed_adjacency_info.shifts[computed_mask, :]
+        computed_displacements = (positions[batch_idx, computed_dst_idx] + computed_shifts
+                                  - positions[batch_idx, computed_src_idx])
 
-        batch_expected_src_idx = expected_src_idx[batch_idx][:valid_count]
-        batch_computed_src_idx = computed_src_idx[batch_idx][:valid_count]
+        permutation_indices = find_aligning_permutation(expected_displacements, computed_displacements, tol=1e-5)
 
-        batch_expected_dst_idx = expected_src_idx[batch_idx][:valid_count]
-        batch_computed_dst_idx = computed_src_idx[batch_idx][:valid_count]
-
-        batch_expected_displacements = expected_displacements[batch_idx][:valid_count]
-        batch_computed_displacements = computed_displacements[batch_idx][:valid_count]
-
-        batch_expected_shifts = expected_shifts[batch_idx][:valid_count]
-        batch_computed_shifts = computed_shifts[batch_idx][:valid_count]
-
-        permutation_indices = find_aligning_permutation(batch_expected_displacements,
-                                                        batch_computed_displacements,
-                                                        tol=1e-5)
-
-        torch.testing.assert_close(batch_computed_displacements[permutation_indices],
-                                   batch_expected_displacements,
-                                   check_dtype=False)
-        torch.testing.assert_close(batch_computed_shifts[permutation_indices],
-                                   batch_expected_shifts,
-                                   check_dtype=False)
-        torch.testing.assert_close(batch_computed_src_idx[permutation_indices], batch_expected_src_idx)
-        torch.testing.assert_close(batch_computed_dst_idx[permutation_indices], batch_expected_dst_idx)
+        torch.testing.assert_close(computed_shifts[permutation_indices], expected_shifts, check_dtype=False)
+        torch.testing.assert_close(computed_src_idx[permutation_indices], expected_src_idx)
+        torch.testing.assert_close(computed_dst_idx[permutation_indices], expected_dst_idx)
 
 
 def test_get_periodic_neighbour_indices_and_displacements_large_cutoff(basis_vectors, relative_coordinates):


### PR DESCRIPTION
This PR fixes an issue in the 'batch tensor' output of the adjacency matrix calculation code. It also tests that the graphs generated by MACE and our approach are identical, up to a permutation of edge indices.

I also remove a bunch of code around ` convert_adjacency_info_into_batched_and_padded_data`. This functionality is not needed and was only introduced because the required output format wasn't clear to me at the time. There is no need to carry this dead wood around, so I tested the code that generates the adjacency matrix and remove this useless stuff.