### PR TITLE
Conditional diffusion part1

### DIFF
--- a/crystal_diffusion/data/diffusion/data_loader.py
+++ b/crystal_diffusion/data/diffusion/data_loader.py
@@ -13,12 +13,12 @@ from torch.utils.data import DataLoader
 
 from crystal_diffusion.data.diffusion.data_preprocess import \
     LammpsProcessorForDiffusion
-from crystal_diffusion.namespace import (CARTESIAN_POSITIONS,
+from crystal_diffusion.namespace import (CARTESIAN_POSITIONS, FORCES,
                                          RELATIVE_COORDINATES)
 
 logger = logging.getLogger(__name__)
 
-NAME_MAPPING = dict(position=CARTESIAN_POSITIONS, relative_positions=RELATIVE_COORDINATES)
+NAME_MAPPING = dict(position=CARTESIAN_POSITIONS, relative_positions=RELATIVE_COORDINATES, forces=FORCES)
 
 
 @dataclass(kw_only=True)
@@ -81,7 +81,7 @@ class LammpsForDiffusionDataModule(pl.LightningDataModule):
         transformed_x['natom'] = torch.as_tensor(x['natom']).long()  # resulting tensor size: (batchsize, )
         bsize = transformed_x['natom'].size(0)
         transformed_x['box'] = torch.as_tensor(x['box'])  # size: (batchsize, spatial dimension)
-        for pos in ['position', 'relative_positions']:
+        for pos in ['position', 'relative_positions', 'forces']:
             transformed_x[NAME_MAPPING[pos]] = torch.as_tensor(x[pos]).view(bsize, -1, spatial_dim)
         transformed_x['type'] = torch.as_tensor(x['type']).long()  # size: (batchsize, max atom)
         transformed_x['potential_energy'] = torch.as_tensor(x['potential_energy'])  # size: (batchsize, )
@@ -104,7 +104,7 @@ class LammpsForDiffusionDataModule(pl.LightningDataModule):
         if natom > max_atom:
             raise ValueError(f"Hyper-parameter max_atom is smaller than an example in the dataset with {natom} atoms.")
         x['type'] = F.pad(torch.as_tensor(x['type']).long(), (0, max_atom - natom), 'constant', -1)
-        for pos in ['position', 'relative_positions']:
+        for pos in ['position', 'relative_positions', 'forces']:
             x[NAME_MAPPING[pos]] = F.pad(torch.as_tensor(x[pos]).float(), (0, spatial_dim * (max_atom - natom)),
                                          'constant', torch.nan)
         return x

--- a/crystal_diffusion/data/diffusion/data_loader.py
+++ b/crystal_diffusion/data/diffusion/data_loader.py
@@ -13,12 +13,12 @@ from torch.utils.data import DataLoader
 
 from crystal_diffusion.data.diffusion.data_preprocess import \
     LammpsProcessorForDiffusion
-from crystal_diffusion.namespace import (CARTESIAN_POSITIONS, FORCES,
+from crystal_diffusion.namespace import (CARTESIAN_FORCES, CARTESIAN_POSITIONS,
                                          RELATIVE_COORDINATES)
 
 logger = logging.getLogger(__name__)
 
-NAME_MAPPING = dict(position=CARTESIAN_POSITIONS, relative_positions=RELATIVE_COORDINATES, forces=FORCES)
+NAME_MAPPING = dict(position=CARTESIAN_POSITIONS, relative_positions=RELATIVE_COORDINATES, forces=CARTESIAN_FORCES)
 
 
 @dataclass(kw_only=True)

--- a/crystal_diffusion/data/diffusion/data_loader.py
+++ b/crystal_diffusion/data/diffusion/data_loader.py
@@ -18,8 +18,6 @@ from crystal_diffusion.namespace import (CARTESIAN_FORCES, CARTESIAN_POSITIONS,
 
 logger = logging.getLogger(__name__)
 
-NAME_MAPPING = dict(position=CARTESIAN_POSITIONS, relative_positions=RELATIVE_COORDINATES, forces=CARTESIAN_FORCES)
-
 
 @dataclass(kw_only=True)
 class LammpsLoaderParameters:
@@ -81,8 +79,8 @@ class LammpsForDiffusionDataModule(pl.LightningDataModule):
         transformed_x['natom'] = torch.as_tensor(x['natom']).long()  # resulting tensor size: (batchsize, )
         bsize = transformed_x['natom'].size(0)
         transformed_x['box'] = torch.as_tensor(x['box'])  # size: (batchsize, spatial dimension)
-        for pos in ['position', 'relative_positions', 'forces']:
-            transformed_x[NAME_MAPPING[pos]] = torch.as_tensor(x[pos]).view(bsize, -1, spatial_dim)
+        for pos in [CARTESIAN_POSITIONS, RELATIVE_COORDINATES, CARTESIAN_FORCES]:
+            transformed_x[pos] = torch.as_tensor(x[pos]).view(bsize, -1, spatial_dim)
         transformed_x['type'] = torch.as_tensor(x['type']).long()  # size: (batchsize, max atom)
         transformed_x['potential_energy'] = torch.as_tensor(x['potential_energy'])  # size: (batchsize, )
 
@@ -104,9 +102,9 @@ class LammpsForDiffusionDataModule(pl.LightningDataModule):
         if natom > max_atom:
             raise ValueError(f"Hyper-parameter max_atom is smaller than an example in the dataset with {natom} atoms.")
         x['type'] = F.pad(torch.as_tensor(x['type']).long(), (0, max_atom - natom), 'constant', -1)
-        for pos in ['position', 'relative_positions', 'forces']:
-            x[NAME_MAPPING[pos]] = F.pad(torch.as_tensor(x[pos]).float(), (0, spatial_dim * (max_atom - natom)),
-                                         'constant', torch.nan)
+        for pos in [CARTESIAN_POSITIONS, RELATIVE_COORDINATES, CARTESIAN_FORCES]:
+            x[pos] = F.pad(torch.as_tensor(x[pos]).float(), (0, spatial_dim * (max_atom - natom)), 'constant',
+                           torch.nan)
         return x
 
     def setup(self, stage: Optional[str] = None):

--- a/crystal_diffusion/data/diffusion/data_preprocess.py
+++ b/crystal_diffusion/data/diffusion/data_preprocess.py
@@ -9,7 +9,7 @@ from typing import List, Optional, Tuple, Union
 import pandas as pd
 
 from crystal_diffusion.data.parse_lammps_outputs import parse_lammps_output
-from crystal_diffusion.namespace import (CARTESIAN_POSITIONS, FORCES,
+from crystal_diffusion.namespace import (CARTESIAN_FORCES, CARTESIAN_POSITIONS,
                                          RELATIVE_COORDINATES)
 
 logger = logging.getLogger(__name__)
@@ -163,8 +163,9 @@ class LammpsProcessorForDiffusion:
         # Parquet cannot handle a list of list; flattening positions.
         df[CARTESIAN_POSITIONS] = df.apply(self._flatten_positions_in_row, axis=1)
         # position is natom * 3 array
-        df[FORCES] = df.apply(partial(self._flatten_positions_in_row, keys=['fx', 'fy', 'fz']), axis=1)
-        return df[['natom', 'box', 'type', 'potential_energy', CARTESIAN_POSITIONS, RELATIVE_COORDINATES, FORCES]]
+        df[CARTESIAN_FORCES] = df.apply(partial(self._flatten_positions_in_row, keys=['fx', 'fy', 'fz']), axis=1)
+        return df[['natom', 'box', 'type', 'potential_energy', CARTESIAN_POSITIONS, RELATIVE_COORDINATES,
+                   CARTESIAN_FORCES]]
 
     @staticmethod
     def _flatten_positions_in_row(row: pd.Series, keys=['x', 'y', 'z']) -> List[float]:

--- a/crystal_diffusion/models/position_diffusion_lightning_model.py
+++ b/crystal_diffusion/models/position_diffusion_lightning_model.py
@@ -120,6 +120,7 @@ class PositionDiffusionLightningModel(pl.LightningModule):
         self,
         batch: typing.Any,
         batch_idx: int,
+        no_conditional: bool = False,
     ) -> typing.Any:
         """Generic step.
 
@@ -147,6 +148,7 @@ class PositionDiffusionLightningModel(pl.LightningModule):
         Args:
             batch : a dictionary that should contain a data sample.
             batch_idx :  index of the batch
+            no_conditional (optional): if True, do not use the conditional option of the forward. Used for validation.
 
         Returns:
             loss : the computed loss.
@@ -185,7 +187,8 @@ class PositionDiffusionLightningModel(pl.LightningModule):
                            UNIT_CELL: unit_cell,
                            CARTESIAN_FORCES: forces}
 
-        predicted_normalized_scores = self.sigma_normalized_score_network(augmented_batch, conditional=None)
+        use_conditional = None if no_conditional is False else False
+        predicted_normalized_scores = self.sigma_normalized_score_network(augmented_batch, conditional=use_conditional)
 
         loss = torch.nn.functional.mse_loss(
             predicted_normalized_scores, target_normalized_conditional_scores, reduction="mean"
@@ -247,7 +250,7 @@ class PositionDiffusionLightningModel(pl.LightningModule):
 
     def validation_step(self, batch, batch_idx):
         """Runs a prediction step for validation, logging the loss."""
-        output = self._generic_step(batch, batch_idx)
+        output = self._generic_step(batch, batch_idx, no_conditional=True)
         loss = output["loss"]
         batch_size = self._get_batch_size(batch)
 

--- a/crystal_diffusion/models/score_network.py
+++ b/crystal_diffusion/models/score_network.py
@@ -141,8 +141,8 @@ class ScoreNetwork(torch.nn.Module):
             cartesian_forces = batch[CARTESIAN_FORCES]
             cartesian_forces_shape = cartesian_forces.shape
             assert (
-                    len(cartesian_forces_shape) == 3 and cartesian_forces_shape[2] == self.spatial_dimension
-            ), ("The cartesian forces are expected to be in a tensor of shape [batch_size, number_of_atoms," 
+                len(cartesian_forces_shape) == 3 and cartesian_forces_shape[2] == self.spatial_dimension
+            ), ("The cartesian forces are expected to be in a tensor of shape [batch_size, number_of_atoms,"
                 f"{self.spatial_dimension}]")
 
     def forward(self, batch: Dict[AnyStr, torch.Tensor], conditional: Optional[bool] = None) -> torch.Tensor:

--- a/crystal_diffusion/models/score_network.py
+++ b/crystal_diffusion/models/score_network.py
@@ -24,7 +24,8 @@ from crystal_diffusion.models.mace_utils import (
     get_pretrained_mace_output_node_features_irreps, input_to_mace)
 from crystal_diffusion.models.score_prediction_head import (
     MaceScorePredictionHeadParameters, instantiate_mace_prediction_head)
-from crystal_diffusion.namespace import (NOISE, NOISY_CARTESIAN_POSITIONS,
+from crystal_diffusion.namespace import (CARTESIAN_FORCES, NOISE,
+                                         NOISY_CARTESIAN_POSITIONS,
                                          NOISY_RELATIVE_COORDINATES, TIME,
                                          UNIT_CELL)
 from crystal_diffusion.utils.basis_transformations import \
@@ -42,6 +43,9 @@ class ScoreNetworkParameters:
     """Base Hyper-parameters for score networks."""
     architecture: str
     spatial_dimension: int = 3  # the dimension of Euclidean space where atoms live.
+    prob_conditional: float = 0.  # probability of making an conditional forward - else, do a unconditional forward
+    conditional_gamma: float = 2.  # conditional score weighting - see eq. B45 in MatterGen
+    # p_\gamma(x|c) = p(c|x)^\gamma p(x)
 
 
 class ScoreNetwork(torch.nn.Module):
@@ -60,6 +64,8 @@ class ScoreNetwork(torch.nn.Module):
         super(ScoreNetwork, self).__init__()
         self._hyper_params = hyper_params
         self.spatial_dimension = hyper_params.spatial_dimension
+        self.prob_conditional = hyper_params.prob_conditional
+        self.conditional_gamma = hyper_params.conditional_gamma
 
     def _check_batch(self, batch: Dict[AnyStr, torch.Tensor]):
         """Check batch.
@@ -127,19 +133,39 @@ class ScoreNetwork(torch.nn.Module):
             and unit_cell_shape[2] == self.spatial_dimension
         ), "The unit cell is expected to be in a tensor of shape [batch_size, spatial_dimension, spatial_dimension]."
 
-    def forward(self, batch: Dict[AnyStr, torch.Tensor]) -> torch.Tensor:
+        if self.prob_conditional > 0:
+            assert CARTESIAN_FORCES in batch, \
+                (f"The cartesian forces should be present in "
+                 f"the batch dictionary with key '{CARTESIAN_FORCES}'")
+
+            cartesian_forces = batch[CARTESIAN_FORCES]
+            cartesian_forces_shape = cartesian_forces.shape
+            assert (
+                    len(cartesian_forces_shape) == 3 and cartesian_forces_shape[2] == self.spatial_dimension
+            ), "The cartesian forces are expected to be in a tensor of shape [batch_size, number_of_atoms,"
+            + f"{self.spatial_dimension}]"
+
+    def forward(self, batch: Dict[AnyStr, torch.Tensor], conditional: Optional[bool] = None) -> torch.Tensor:
         """Model forward.
 
         Args:
             batch : dictionary containing the data to be processed by the model.
+            conditional: if True, do an conditional forward, if False, do a unconditional forward. If None, choose
+                randomly with probability prob_conditional
 
         Returns:
             computed_scores : the scores computed by the model.
         """
         self._check_batch(batch)
-        return self._forward_unchecked(batch)
+        if conditional is None:
+            conditional = torch.rand(1,) < self.prob_conditional
+        if conditional:
+            return self._forward_unchecked(batch, conditional=False)
+        else:
+            return (self._forward_unchecked(batch, conditional=True) * self.conditional_gamma
+                    + self._forward_unchecked(batch, conditional=False) * (1 - self.conditional_gamma))
 
-    def _forward_unchecked(self, batch: Dict[AnyStr, torch.Tensor]) -> torch.Tensor:
+    def _forward_unchecked(self, batch: Dict[AnyStr, torch.Tensor], conditional: bool = False) -> torch.Tensor:
         """Forward unchecked.
 
         This method assumes that the input data has already been checked with respect to expectations
@@ -149,6 +175,7 @@ class ScoreNetwork(torch.nn.Module):
 
         Args:
             batch : dictionary containing the data to be processed by the model.
+            conditional (optional): if True, do a forward as though the model was conditional on the forces.
 
         Returns:
             computed_scores : the scores computed by the model.
@@ -159,10 +186,12 @@ class ScoreNetwork(torch.nn.Module):
 @dataclass(kw_only=True)
 class MLPScoreNetworkParameters(ScoreNetworkParameters):
     """Specific Hyper-parameters for MLP score networks."""
+
     architecture: str = 'mlp'
     number_of_atoms: int  # the number of atoms in a configuration.
     n_hidden_dimensions: int  # the number of hidden layers.
     hidden_dimensions_size: int  # the dimensions of the hidden layers.
+    condition_embedding_size: int = 64  # dimension of the conditional variable embedding
 
 
 class MLPScoreNetwork(ScoreNetwork):
@@ -184,17 +213,18 @@ class MLPScoreNetwork(ScoreNetwork):
         output_dimension = self.spatial_dimension * self._natoms
         input_dimension = output_dimension + 1
 
+        self.condition_embedding_layer = nn.Linear(output_dimension, hyper_params.condition_embedding_size)
+
         self.flatten = nn.Flatten()
-        self.mlp_layers = nn.Sequential()
+        self.mlp_layers = nn.ModuleList()
+        self.conditional_layers = nn.ModuleList()
         input_dimensions = [input_dimension] + hidden_dimensions
         output_dimensions = hidden_dimensions + [output_dimension]
-        add_relus = len(input_dimensions) * [True]
-        add_relus[-1] = False
 
-        for input_dimension, output_dimension, add_relu in zip(input_dimensions, output_dimensions, add_relus):
+        for input_dimension, output_dimension, add_relu in zip(input_dimensions, output_dimensions):
             self.mlp_layers.append(nn.Linear(input_dimension, output_dimension))
-            if add_relu:
-                self.mlp_layers.append(nn.ReLU())
+            self.conditional_layers.append(nn.Linear(hyper_params.condition_embedding_size, output_dimension))
+        self.non_linearity = nn.ReLU()
 
     def _check_batch(self, batch: Dict[AnyStr, torch.Tensor]):
         super(MLPScoreNetwork, self)._check_batch(batch)
@@ -203,7 +233,7 @@ class MLPScoreNetwork(ScoreNetwork):
             number_of_atoms == self._natoms
         ), "The dimension corresponding to the number of atoms is not consistent with the configuration."
 
-    def _forward_unchecked(self, batch: Dict[AnyStr, torch.Tensor]) -> torch.Tensor:
+    def _forward_unchecked(self, batch: Dict[AnyStr, torch.Tensor], conditional: bool = False) -> torch.Tensor:
         """Forward unchecked.
 
         This method assumes that the input data has already been checked with respect to expectations
@@ -211,6 +241,8 @@ class MLPScoreNetwork(ScoreNetwork):
 
         Args:
             batch : dictionary containing the data to be processed by the model.
+            conditional (optional): if True, do a forward as though the model was conditional on the forces.
+                Defaults to False.
 
         Returns:
             computed_scores : the scores computed by the model.
@@ -221,6 +253,15 @@ class MLPScoreNetwork(ScoreNetwork):
         times = batch[TIME].to(relative_coordinates.device)  # shape [batch_size, 1]
         input = torch.cat([self.flatten(relative_coordinates), times], dim=1)
 
+        forces_input = self.condition_embedding_layer(self.flatten(batch[CARTESIAN_FORCES]))
+
+        for i, (layer, condition_layer) in enumerate(zip(self.mlp_layers, self.conditional_layers)):
+            if i != 0:
+                input = self.non_linearity(input)
+            input = layer(input)
+            if conditional:
+                input += condition_layer(forces_input)
+
         output = self.mlp_layers(input).reshape(relative_coordinates.shape)
         return output
 
@@ -228,6 +269,7 @@ class MLPScoreNetwork(ScoreNetwork):
 @dataclass(kw_only=True)
 class MACEScoreNetworkParameters(ScoreNetworkParameters):
     """Specific Hyper-parameters for MACE score networks."""
+
     architecture: str = 'mace'
     number_of_atoms: int  # the number of atoms in a configuration.
     use_pretrained: Optional[str] = None  # if None, do not use pre-trained ; else, should be in small, medium or large
@@ -313,7 +355,7 @@ class MACEScoreNetwork(ScoreNetwork):
             number_of_atoms == self._natoms
         ), "The dimension corresponding to the number of atoms is not consistent with the configuration."
 
-    def _forward_unchecked(self, batch: Dict[AnyStr, torch.Tensor]) -> torch.Tensor:
+    def _forward_unchecked(self, batch: Dict[AnyStr, torch.Tensor], conditional: bool = False) -> torch.Tensor:
         """Forward unchecked.
 
         This method assumes that the input data has already been checked with respect to expectations
@@ -321,10 +363,13 @@ class MACEScoreNetwork(ScoreNetwork):
 
         Args:
             batch : dictionary containing the data to be processed by the model.
+            conditional (optional): if True, do a forward as though the model was conditional on the forces.
+                Defaults to False.
 
         Returns:
             output : the scores computed by the model as a [batch_size, n_atom, spatial_dimension] tensor.
         """
+        del conditional  # TODO implement conditional
         relative_coordinates = batch[NOISY_RELATIVE_COORDINATES]
         batch[NOISY_CARTESIAN_POSITIONS] = torch.bmm(relative_coordinates, batch[UNIT_CELL])  # positions in Angstrom
         graph_input = input_to_mace(batch, radial_cutoff=self.r_max)
@@ -413,7 +458,7 @@ class DiffusionMACEScoreNetwork(ScoreNetwork):
             number_of_atoms == self._natoms
         ), "The dimension corresponding to the number of atoms is not consistent with the configuration."
 
-    def _forward_unchecked(self, batch: Dict[AnyStr, torch.Tensor]) -> torch.Tensor:
+    def _forward_unchecked(self, batch: Dict[AnyStr, torch.Tensor], conditional: bool = False) -> torch.Tensor:
         """Forward unchecked.
 
         This method assumes that the input data has already been checked with respect to expectations
@@ -421,10 +466,13 @@ class DiffusionMACEScoreNetwork(ScoreNetwork):
 
         Args:
             batch : dictionary containing the data to be processed by the model.
+            conditional (optional): if True, do a forward as though the model was conditional on the forces.
+                Defaults to False.
 
         Returns:
             output : the scores computed by the model as a [batch_size, n_atom, spatial_dimension] tensor.
         """
+        del conditional  # TODO do something with forces when conditional
         relative_coordinates = batch[NOISY_RELATIVE_COORDINATES]
         batch_size, number_of_atoms, spatial_dimension = relative_coordinates.shape
 

--- a/crystal_diffusion/namespace.py
+++ b/crystal_diffusion/namespace.py
@@ -12,6 +12,7 @@ represent these concepts.
 
 CARTESIAN_POSITIONS = "cartesian_positions"   # position in real cartesian space
 RELATIVE_COORDINATES = "relative_coordinates"   # coordinates in the unit cell basis
+CARTESIAN_FORCES = "cartesian_forces"
 
 NOISY_RELATIVE_COORDINATES = "noisy_relative_coordinates"   # relative coordinates perturbed by diffusion noise
 NOISY_CARTESIAN_POSITIONS = "noisy_cartesian_positions"   # cartesian positions perturbed by diffusion noise

--- a/crystal_diffusion/samplers/predictor_corrector_position_sampler.py
+++ b/crystal_diffusion/samplers/predictor_corrector_position_sampler.py
@@ -50,7 +50,7 @@ class PredictorCorrectorPositionSampler(ABC):
             + f"Got {unit_cell.size()}"
 
         x_ip1 = map_relative_coordinates_to_unit_cell(self.initialize(number_of_samples)).to(device)
-        forces = torch.zeros_lie(x_ip1)
+        forces = torch.zeros_like(x_ip1)
 
         for i in tqdm(range(self.number_of_discretization_steps - 1, -1, -1)):
             x_i = map_relative_coordinates_to_unit_cell(self.predictor_step(x_ip1, i + 1, unit_cell, forces))

--- a/examples/local/diffusion/config_diffusion_mlp.yaml
+++ b/examples/local/diffusion/config_diffusion_mlp.yaml
@@ -20,6 +20,8 @@ spatial_dimension: 3
 model:
   score_network:
     architecture: mlp
+    conditional_prob: 0.0
+    conditional_gamma: 2
     number_of_atoms: 8
     n_hidden_dimensions: 2
     hidden_dimensions_size: 64

--- a/tests/data/diffusion/test_data_preprocess.py
+++ b/tests/data/diffusion/test_data_preprocess.py
@@ -6,6 +6,7 @@ import pytest
 
 from crystal_diffusion.data.diffusion.data_preprocess import \
     LammpsProcessorForDiffusion
+from crystal_diffusion.namespace import CARTESIAN_POSITIONS, CARTESIAN_FORCES, RELATIVE_COORDINATES
 from tests.conftest import TestDiffusionDataBase
 from tests.fake_data_utils import generate_parquet_dataframe
 
@@ -41,7 +42,8 @@ class TestDataProcess(TestDiffusionDataBase):
             pd.testing.assert_frame_equal(computed_df, expected_df)
 
     def test_parse_lammps_run(self, processor, paths, train_configuration_runs, valid_configuration_runs):
-        expected_columns = ['natom', 'box', 'type', 'position', 'relative_positions', 'potential_energy']
+        expected_columns = ['natom', 'box', 'type', CARTESIAN_POSITIONS, CARTESIAN_FORCES, RELATIVE_COORDINATES,
+                            'potential_energy']
 
         for mode, configuration_runs in zip(['train', 'valid'], [train_configuration_runs, valid_configuration_runs]):
 
@@ -85,7 +87,7 @@ class TestDataProcess(TestDiffusionDataBase):
 
             natom = len(configuration.ids)
             expected_coordinates = configuration.relative_coordinates
-            positions = configuration.positions
+            positions = configuration.cartesian_positions
             box = configuration.cell_dimensions
 
             position_series = pd.Series({'x': positions[:, 0], 'y': positions[:, 1], 'z': positions[:, 2], 'box': box})
@@ -97,7 +99,7 @@ class TestDataProcess(TestDiffusionDataBase):
         # Call get_x_relative on the test data
         result_df = processor.get_x_relative(sample_coordinates)
         # Check if 'relative_positions' column is added
-        assert 'relative_positions' in result_df.columns
+        assert RELATIVE_COORDINATES in result_df.columns
 
     def test_flatten_positions_in_row(self):
 

--- a/tests/models/test_position_diffusion_lightning_model.py
+++ b/tests/models/test_position_diffusion_lightning_model.py
@@ -11,7 +11,7 @@ from crystal_diffusion.models.scheduler import (
     CosineAnnealingLRSchedulerParameters, ReduceLROnPlateauSchedulerParameters,
     ValidSchedulerName)
 from crystal_diffusion.models.score_network import MLPScoreNetworkParameters
-from crystal_diffusion.namespace import RELATIVE_COORDINATES
+from crystal_diffusion.namespace import CARTESIAN_FORCES, RELATIVE_COORDINATES
 from crystal_diffusion.samplers.variance_sampler import NoiseParameters
 from crystal_diffusion.score.wrapped_gaussian_score import \
     get_sigma_normalized_score_brute_force
@@ -36,7 +36,8 @@ class FakePositionsDataModule(LightningDataModule):
         all_relative_coordinates = torch.rand(dataset_size, number_of_atoms, spatial_dimension)
         box = torch.rand(spatial_dimension)
         self.data = [
-            {RELATIVE_COORDINATES: configuration, 'box': box} for configuration in all_relative_coordinates
+            {RELATIVE_COORDINATES: configuration, 'box': box, CARTESIAN_FORCES: torch.zeros_like(configuration)}
+            for configuration in all_relative_coordinates
         ]
         self.train_data, self.val_data, self.test_data = None, None, None
 

--- a/tests/models/test_score_network.py
+++ b/tests/models/test_score_network.py
@@ -8,8 +8,9 @@ from crystal_diffusion.models.score_network import (
 from crystal_diffusion.models.score_prediction_head import (
     MaceEquivariantScorePredictionHeadParameters,
     MaceMLPScorePredictionHeadParameters)
-from crystal_diffusion.namespace import (NOISE, NOISY_RELATIVE_COORDINATES,
-                                         TIME, UNIT_CELL)
+from crystal_diffusion.namespace import (CARTESIAN_FORCES, NOISE,
+                                         NOISY_RELATIVE_COORDINATES, TIME,
+                                         UNIT_CELL)
 
 
 @pytest.mark.parametrize("spatial_dimension", [2, 3])
@@ -132,6 +133,11 @@ class BaseTestScoreNetwork:
         return relative_coordinates
 
     @pytest.fixture
+    def cartesian_forces(self, batch_size, number_of_atoms, spatial_dimension, basis_vectors):
+        cartesian_forces = torch.rand(batch_size, number_of_atoms, spatial_dimension)
+        return cartesian_forces
+
+    @pytest.fixture
     def times(self, batch_size):
         times = torch.rand(batch_size, 1)
         return times
@@ -145,8 +151,9 @@ class BaseTestScoreNetwork:
         return batch_size, number_of_atoms, spatial_dimension
 
     @pytest.fixture()
-    def batch(self, relative_coordinates, times, noises, basis_vectors):
-        return {NOISY_RELATIVE_COORDINATES: relative_coordinates, TIME: times, UNIT_CELL: basis_vectors, NOISE: noises}
+    def batch(self, relative_coordinates, cartesian_forces, times, noises, basis_vectors):
+        return {NOISY_RELATIVE_COORDINATES: relative_coordinates, TIME: times, UNIT_CELL: basis_vectors, NOISE: noises,
+                CARTESIAN_FORCES: cartesian_forces}
 
     def test_output_shape(self, score_network, batch, expected_score_shape):
         scores = score_network(batch)


### PR DESCRIPTION
in this PR, I implement a conditional version of the score network based on the classifier-free guidance approach. In short, the modified score becomes:
<img width="325" alt="image" src="https://github.com/mila-iqia/diffusion_for_multi_scale_molecular_dynamics/assets/35506852/89bdc213-234d-4049-960a-a8d60093d5f7">
where I used \gamma = 1 + w instead to match the convention in MatterGen (hyper-parameter in the config file - set to 2 by default as per MatterGen). The second term on the right-hand side is the usual score network. The first one is a modified version that takes a condition c - here the cartesian forces - as an input. This modification takes the form of an added value in MatterGen:
![image](https://github.com/mila-iqia/diffusion_for_multi_scale_molecular_dynamics/assets/35506852/90c4b3f4-caa7-4930-a2ea-17d060956548)
where H is the node features at a given layer in the GNN used (GemNet in the case of MatterGen). Here, I implemented the added value as a linear layer on top of each layer of the MLP approach. I didn't tackle MACE yet.

During training, a forward for a batch can be done unconditionally (as if the property was null) or conditionally. The probability is set by an hyper-parameter in the config file. This is different from MatterGen where training was first done unconditionally, then fine-tuned on the conditions.