### PR TITLE
rewrite the mace equivariant head to avoid a model explosion

### DIFF
--- a/crystal_diffusion/models/score_prediction_head.py
+++ b/crystal_diffusion/models/score_prediction_head.py
@@ -104,7 +104,7 @@ class MaceEquivariantScorePredictionHead(MaceScorePredictionHead):
         # by the various subsequent layers.
         head_input_irreps = time_irreps_out + output_node_features_irreps
 
-        sorted_irreps, self.column_permutation_indices = (
+        sorted_irreps, _ = (
             get_normalized_irreps_permutation_indices(head_input_irreps))
 
         # mix the time embedding 0e irrep with the different components of the MACE output and avoid a dimensionality
@@ -154,7 +154,6 @@ class MaceEquivariantScorePredictionHead(MaceScorePredictionHead):
         flat_scores = self.head(mixed_features)
 
         return flat_scores
-
 
 
 # Register the possible MACE prediction heads as  key:  model class


### PR DESCRIPTION
original model:
time embedding + mace output -> 
o3.Linear -> o3.BatchNorm -> o3.TensorSquare -> non linearity
The TensorSquare had a lot of weights and was probably overkill for our purpose. Its goal was to mix the time information across the different channels of MACE, but it was also computing a lot of useless stuff. 

I replaced with the following:
FullyConnectedTensorProduct(time embedding, mace output) ->
 o3.Linear -> o3.BatchNorm -> non linearity
 the FCTP mixes time with all the components of the mace output and we can control the dimensionality of its output. No need for a TensorSquare anymore
 We probably could simplify even more by allowing only the 0e channel as the output of the FCTP since the next layers should not mix different ells