### PR TITLE
gradient accumulation

### DIFF
--- a/crystal_diffusion/train_diffusion.py
+++ b/crystal_diffusion/train_diffusion.py
@@ -168,6 +168,7 @@ def train(model,
         devices=devices,
         logger=pl_loggers,
         gradient_clip_val=hyper_params.get('gradient_clipping', 0),
+        accumulate_grad_batches=hyper_params.get('accumulate_grad_batches', 1)
     )
 
     # Using the keyword ckpt_path="last" tells the trainer to resume from the last

--- a/examples/local/diffusion/config_diffusion_mace.yaml
+++ b/examples/local/diffusion/config_diffusion_mace.yaml
@@ -4,6 +4,7 @@ run_name: run_debug_delete_me
 max_epoch: 10
 log_every_n_steps: 1
 gradient_clipping: 0.1
+accumulate_grad_batches: 1  # make this number of forward passes before doing a backprop step
 
 # set to null to avoid setting a seed (can speed up GPU computation, but
 # results will not be reproducible)

--- a/examples/local/diffusion/config_diffusion_mlp.yaml
+++ b/examples/local/diffusion/config_diffusion_mlp.yaml
@@ -4,6 +4,7 @@ run_name: run_debug_delete_me
 max_epoch: 10
 log_every_n_steps: 1
 gradient_clipping: 0
+accumulate_grad_batches: 1  # make this number of forward passes before doing a backprop step
 
 # set to null to avoid setting a seed (can speed up GPU computation, but
 # results will not be reproducible)

--- a/examples/local/diffusion/config_mace_equivariant_head.yaml
+++ b/examples/local/diffusion/config_mace_equivariant_head.yaml
@@ -3,6 +3,7 @@ exp_name: mace_equivariant_head_example
 run_name: run_debug_delete_me
 max_epoch: 10
 log_every_n_steps: 1
+accumulate_grad_batches: 1  # make this number of forward passes before doing a backprop step
 
 # set to null to avoid setting a seed (can speed up GPU computation, but
 # results will not be reproducible)

--- a/examples/local/diffusion/config_mace_mlp_head.yaml
+++ b/examples/local/diffusion/config_mace_mlp_head.yaml
@@ -3,6 +3,7 @@ exp_name: mace_mlp_head_example
 run_name: run_debug_delete_me
 max_epoch: 10
 log_every_n_steps: 1
+accumulate_grad_batches: 1  # make this number of forward passes before doing a backprop step
 
 # set to null to avoid setting a seed (can speed up GPU computation, but
 # results will not be reproducible)


### PR DESCRIPTION
Adding a kwarg to allow for gradient accumulation.
In the normal MACE and the MLP score network, there is no batchnorm, so doing gradient accumulation is easy.
Here, just passing an argument to pytorch-lightning trainer does the trick.

TBD what happens with DiffusionMACE with the o3.batchnorm...