### PR TITLE
Fokker planck

### DIFF
--- a/crystal_diffusion/generators/sde_position_generator.py
+++ b/crystal_diffusion/generators/sde_position_generator.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 class SDESamplingParameters(SamplingParameters):
     """Hyper-parameters for diffusion sampling with the sde algorithm."""
     algorithm: str = 'sde'
+    sde_type: str = 'ito'
     method: str = 'euler'
     adaptative: bool = False
     absolute_solver_tolerance: float = 1.0e-7  # the absolute error tolerance passed to the SDE solver.
@@ -60,6 +61,7 @@ class SDE(torch.nn.Module):
             final_diffusion_time : final diffusion time. Dimensionless tensor.
         """
         super().__init__()
+        self.sde_type = sampling_parameters.sde_type
         self.noise_parameters = noise_parameters
         self.sigma_normalized_score_network = sigma_normalized_score_network
         self.unit_cells = unit_cells
@@ -284,7 +286,7 @@ class ExplodingVarianceSDEPositionGenerator(PositionGenerator):
     def record_sample(self, sde: SDE, ys: torch.Tensor, sde_times: torch.Tensor):
         """Record sample.
 
-        This method takes care of recomputing the normalized score on the solution trajectory and record it to the
+        This  takes care of recomputing the normalized score on the solution trajectory and record it to the
         sample trajectory object.
         Args:
             sde: the SDE object that provides drift and diffusion.

--- a/crystal_diffusion/generators/sde_position_generator.py
+++ b/crystal_diffusion/generators/sde_position_generator.py
@@ -259,14 +259,14 @@ class ExplodingVarianceSDEPositionGenerator(PositionGenerator):
 
         with torch.no_grad():
             # Dimensions [number of time steps, number of samples, natom x spatial_dimension]
-            logger.info("Starting ODE solver...")
+            logger.info("Starting SDE solver...")
             ys = torchsde.sdeint(sde, y0, sde_times,
                                  method=self.sampling_parameters.method,
                                  dt=dt,
                                  adaptive=self.sampling_parameters.adaptative,
                                  atol=self.sampling_parameters.absolute_solver_tolerance,
                                  rtol=self.sampling_parameters.relative_solver_tolerance)
-            logger.info("ODE solver Finished.")
+            logger.info("SDE solver Finished.")
 
         if self.record_samples:
             self.record_sample(sde, ys, sde_times)

--- a/crystal_diffusion/generators/sde_position_generator.py
+++ b/crystal_diffusion/generators/sde_position_generator.py
@@ -24,9 +24,9 @@ class SDESamplingParameters(SamplingParameters):
     """Hyper-parameters for diffusion sampling with the sde algorithm."""
     algorithm: str = 'sde'
     method: str = 'euler'
-    adaptative: bool = True
-    absolute_solver_tolerance: float = 1.0e-3  # the absolute error tolerance passed to the SDE solver.
-    relative_solver_tolerance: float = 1.0e-2  # the relative error tolerance passed to the SDE solver.
+    adaptative: bool = False
+    absolute_solver_tolerance: float = 1.0e-7  # the absolute error tolerance passed to the SDE solver.
+    relative_solver_tolerance: float = 1.0e-5  # the relative error tolerance passed to the SDE solver.
 
 
 class SDE(torch.nn.Module):

--- a/crystal_diffusion/generators/sde_position_generator.py
+++ b/crystal_diffusion/generators/sde_position_generator.py
@@ -1,0 +1,322 @@
+import logging
+from dataclasses import dataclass
+
+import einops
+import torch
+import torchsde
+
+from crystal_diffusion.generators.position_generator import (
+    PositionGenerator, SamplingParameters)
+from crystal_diffusion.models.score_networks import ScoreNetwork
+from crystal_diffusion.namespace import (CARTESIAN_FORCES, NOISE,
+                                         NOISY_RELATIVE_COORDINATES, TIME,
+                                         UNIT_CELL)
+from crystal_diffusion.samplers.variance_sampler import NoiseParameters
+from crystal_diffusion.utils.basis_transformations import \
+    map_relative_coordinates_to_unit_cell
+from crystal_diffusion.utils.sample_trajectory import SDESampleTrajectory
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(kw_only=True)
+class SDESamplingParameters(SamplingParameters):
+    """Hyper-parameters for diffusion sampling with the sde algorithm."""
+    algorithm: str = 'sde'
+    method: str = 'euler'
+    adaptative: bool = True
+    absolute_solver_tolerance: float = 1.0e-3  # the absolute error tolerance passed to the SDE solver.
+    relative_solver_tolerance: float = 1.0e-2  # the relative error tolerance passed to the SDE solver.
+
+
+class SDE(torch.nn.Module):
+    """SDE.
+
+    This class computes the drift and the diffusion coefficients in order to be consisent with the expectations
+    of the torchsde library.
+    """
+    noise_type = 'diagonal'  # we assume that there is a distinct Wiener process for each component.
+    sde_type = 'ito'
+
+    def __init__(self,
+                 noise_parameters: NoiseParameters,
+                 sampling_parameters: SDESamplingParameters,
+                 sigma_normalized_score_network: ScoreNetwork,
+                 unit_cells: torch.Tensor,
+                 initial_diffusion_time: torch.Tensor,
+                 final_diffusion_time: torch.Tensor):
+        """Init method.
+
+        This class will provide drift and diffusion for the torchsde solver. The SDE will be solved
+        "backwards" in diffusion time, such that the sde time will start where the diffusion ends, and vice-versa.
+
+        Args:
+            noise_parameters: parameters defining the noise schedule.
+            sampling_parameters : parameters defining the sampling procedure.
+            sigma_normalized_score_network : the score network to use for drawing samples.
+            unit_cells: unit cell definition in Angstrom.
+                Tensor of dimensions [number_of_samples, spatial_dimension, spatial_dimension]
+            initial_diffusion_time : initial diffusion time. Dimensionless tensor.
+            final_diffusion_time : final diffusion time. Dimensionless tensor.
+        """
+        super().__init__()
+        self.noise_parameters = noise_parameters
+        self.sigma_normalized_score_network = sigma_normalized_score_network
+        self.unit_cells = unit_cells
+        self.number_of_atoms = sampling_parameters.number_of_atoms
+        self.spatial_dimension = sampling_parameters.spatial_dimension
+        self.initial_diffusion_time = initial_diffusion_time
+        self.final_diffusion_time = final_diffusion_time
+
+    def _get_exploding_variance_sigma(self, diffusion_time: torch.Tensor) -> torch.Tensor:
+        """Get Exploding Variance Sigma.
+
+        In the 'exploding variance' scheme, the noise is defined by
+
+            sigma(t) = sigma_min^{1- t} x sigma_max^{t}
+
+        Args:
+            diffusion_time : diffusion time
+
+        Returns:
+            sigma: value of the noise parameter.
+        """
+        sigma = (self.noise_parameters.sigma_min ** (1.0 - diffusion_time)
+                 * self.noise_parameters.sigma_max ** diffusion_time)
+        return sigma
+
+    def _get_diffusion_coefficient_g_squared(self, diffusion_time: torch.Tensor) -> torch.Tensor:
+        """Get diffusion coefficient g(t)^2.
+
+        The noise is given by sigma(t) = sigma_{min} (sigma_{max} / sigma_{min})^t
+        and g(t)^2 = d/dt sigma(t)^2.
+
+        Args:
+            diffusion_time : Diffusion time.
+
+        Returns:
+            coefficient_g : the coefficient g(t)
+        """
+        s_min = torch.tensor(self.noise_parameters.sigma_min)
+        ratio = torch.tensor(self.noise_parameters.sigma_max / self.noise_parameters.sigma_min)
+
+        g_squared = 2.0 * (s_min * ratio ** diffusion_time) ** 2 * torch.log(ratio)
+        return g_squared
+
+    def _get_diffusion_time(self, sde_time: torch.Tensor) -> torch.Tensor:
+        """Get diffusion time.
+
+        Args:
+            sde_time : SDE time.
+
+        Returns:
+            diffusion_time: the time for the diffusion process.
+        """
+        return self.final_diffusion_time - sde_time
+
+    def f(self, sde_time: torch.Tensor, flat_relative_coordinates: torch.Tensor) -> torch.Tensor:
+        """Drift function.
+
+        Args:
+            sde_time : time for the SDE. Dimensionless tensor.
+            flat_relative_coordinates : time-dependent state. This corresponds to flattened atomic coordinates.
+                Dimension: [batch_size (number of samples), natoms x spatial_dimension]
+
+        Returns:
+            f : the drift.
+        """
+        diffusion_time = self._get_diffusion_time(sde_time)
+
+        sigma_normalized_scores = self.get_sigma_normalized_score(diffusion_time, flat_relative_coordinates)
+        flat_sigma_normalized_scores = einops.rearrange(sigma_normalized_scores,
+                                                        "batch natom space -> batch (natom space)")
+
+        g_squared = self._get_diffusion_coefficient_g_squared(diffusion_time)
+        sigma = self._get_exploding_variance_sigma(diffusion_time)
+        prefactor = -g_squared / sigma
+
+        return prefactor * flat_sigma_normalized_scores
+
+    def get_sigma_normalized_score(self, diffusion_time: torch.Tensor,
+                                   flat_relative_coordinates: torch.Tensor) -> torch.Tensor:
+        """Get sigma normalized score.
+
+        This is a utility method to wrap around the computation of the sigma normalized score in this context,
+        dealing with dimensions and tensor reshapes as needed.
+
+        Args:
+            diffusion_time : the diffusion time. Dimensionless tensor.
+            flat_relative_coordinates : the flat relative coordinates.
+                Dimension [batch_size, natoms x spatial_dimensions]
+
+        Returns:
+            sigma_normalized_score: the sigma normalized score.
+                Dimension [batch_size, natoms, spatial_dimensions]
+        """
+        batch_size = flat_relative_coordinates.shape[0]
+        sigma = self._get_exploding_variance_sigma(diffusion_time)
+        sigmas = einops.repeat(sigma.unsqueeze(0), "1 -> batch 1", batch=batch_size)
+        times = einops.repeat(diffusion_time.unsqueeze(0), "1 -> batch 1", batch=batch_size)
+
+        relative_coordinates = einops.rearrange(flat_relative_coordinates,
+                                                "batch (natom space) -> batch natom space",
+                                                natom=self.number_of_atoms,
+                                                space=self.spatial_dimension)
+        batch = {NOISY_RELATIVE_COORDINATES: map_relative_coordinates_to_unit_cell(relative_coordinates),
+                 NOISE: sigmas,
+                 TIME: times,
+                 UNIT_CELL: self.unit_cells,
+                 CARTESIAN_FORCES: torch.zeros_like(relative_coordinates)  # TODO: handle forces correctly.
+                 }
+        # Shape [batch_size, number of atoms, spatial dimension]
+        sigma_normalized_scores = self.sigma_normalized_score_network(batch)
+        return sigma_normalized_scores
+
+    def g(self, sde_time, y):
+        """Diffusion function."""
+        diffusion_time = self._get_diffusion_time(sde_time)
+        g_squared = self._get_diffusion_coefficient_g_squared(diffusion_time)
+        g_of_t = torch.sqrt(g_squared)
+
+        return g_of_t * torch.ones_like(y)
+
+
+class ExplodingVarianceSDEPositionGenerator(PositionGenerator):
+    """Exploding Variance SDE Position Generator.
+
+    This class generates position samples by solving a stochastic differential equation (SDE).
+    It assumes that the diffusion noise is parameterized in the 'Exploding Variance' scheme.
+    """
+    def __init__(self,
+                 noise_parameters: NoiseParameters,
+                 sampling_parameters: SDESamplingParameters,
+                 sigma_normalized_score_network: ScoreNetwork,
+                 ):
+        """Init method.
+
+        Args:
+            noise_parameters : the diffusion noise parameters.
+            sampling_parameters: the parameters needed for sampling.
+            sigma_normalized_score_network : the score network to use for drawing samples.
+        """
+        self.initial_diffusion_time = torch.tensor(0.0)
+        self.final_diffusion_time = torch.tensor(1.0)
+
+        self.noise_parameters = noise_parameters
+        self.sigma_normalized_score_network = sigma_normalized_score_network
+        self.sampling_parameters = sampling_parameters
+
+        self.number_of_atoms = sampling_parameters.number_of_atoms
+        self.spatial_dimension = sampling_parameters.spatial_dimension
+        self.absolute_solver_tolerance = sampling_parameters.absolute_solver_tolerance
+        self.relative_solver_tolerance = sampling_parameters.relative_solver_tolerance
+        self.record_samples = sampling_parameters.record_samples
+        if self.record_samples:
+            self.sample_trajectory_recorder = SDESampleTrajectory()
+
+    def get_sde(self, unit_cells: torch.Tensor) -> SDE:
+        """Get SDE."""
+        return SDE(noise_parameters=self.noise_parameters,
+                   sampling_parameters=self.sampling_parameters,
+                   sigma_normalized_score_network=self.sigma_normalized_score_network,
+                   unit_cells=unit_cells,
+                   initial_diffusion_time=self.initial_diffusion_time,
+                   final_diffusion_time=self.final_diffusion_time)
+
+    def initialize(self, number_of_samples: int):
+        """This method must initialize the samples from the fully noised distribution."""
+        relative_coordinates = torch.rand(number_of_samples, self.number_of_atoms, self.spatial_dimension)
+        return relative_coordinates
+
+    def sample(self, number_of_samples: int, device: torch.device, unit_cell: torch.Tensor) -> torch.Tensor:
+        """Sample.
+
+        This method draws a position sample.
+
+        Args:
+            number_of_samples : number of samples to draw.
+            device: device to use (cpu, cuda, etc.). Should match the PL model location.
+            unit_cell: unit cell definition in Angstrom.
+                Tensor of dimensions [number_of_samples, spatial_dimension, spatial_dimension]
+
+        Returns:
+            samples: relative coordinates samples.
+        """
+        sde = self.get_sde(unit_cell)
+        sde.to(device)
+
+        initial_relative_coordinates = (
+            map_relative_coordinates_to_unit_cell(self.initialize(number_of_samples)).to(device))
+        y0 = einops.rearrange(initial_relative_coordinates, 'batch natom space -> batch (natom space)')
+
+        sde_times = torch.linspace(self.initial_diffusion_time, self.final_diffusion_time,
+                                   self.noise_parameters.total_time_steps).to(device)
+
+        with torch.no_grad():
+            # Dimensions [number of time steps, number of samples, natom x spatial_dimension]
+            logger.info("Starting ODE solver...")
+            ys = torchsde.sdeint(sde, y0, sde_times,
+                                 method=self.sampling_parameters.method,
+                                 adaptive=self.sampling_parameters.adaptative,
+                                 atol=self.sampling_parameters.absolute_solver_tolerance,
+                                 rtol=self.sampling_parameters.relative_solver_tolerance)
+            logger.info("ODE solver Finished.")
+
+        if self.record_samples:
+            self.record_sample(sde, ys, sde_times)
+
+        # only the final sde time (ie, diffusion time t0) is the real sample.
+        flat_relative_coordinates = ys[-1, :, :]
+
+        relative_coordinates = einops.rearrange(flat_relative_coordinates,
+                                                'batch (natom space) -> batch natom space',
+                                                natom=self.number_of_atoms,
+                                                space=self.spatial_dimension)
+
+        return map_relative_coordinates_to_unit_cell(relative_coordinates)
+
+    def record_sample(self, sde: SDE, ys: torch.Tensor, sde_times: torch.Tensor):
+        """Record sample.
+
+        This method takes care of recomputing the normalized score on the solution trajectory and record it to the
+        sample trajectory object.
+        Args:
+            sde: the SDE object that provides drift and diffusion.
+            ys: the SDE solutions.
+                Dimensions [number of time steps, number of samples, natom x spatial_dimension]
+            sde_times : times along the sde trajectory.
+
+        Returns:
+            None
+        """
+        self.sample_trajectory_recorder.record_unit_cell(sde.unit_cells)
+
+        list_normalized_scores = []
+        sigmas = []
+        evaluation_times = []
+        # Reverse the times since the SDE times are inverted compared to the diffusion times.
+        for sde_time, flat_relative_coordinates in zip(sde_times.flip(dims=(0,)), ys.flip(dims=(0,))):
+            diffusion_time = sde._get_diffusion_time(sde_time)
+            sigma = sde._get_exploding_variance_sigma(diffusion_time)
+            sigmas.append(sigma)
+            evaluation_times.append(diffusion_time)
+
+            with torch.no_grad():
+                normalized_scores = sde.get_sigma_normalized_score(diffusion_time, flat_relative_coordinates)
+            list_normalized_scores.append(normalized_scores)
+
+        sigmas = torch.tensor(sigmas)
+        evaluation_times = torch.tensor(evaluation_times)
+
+        record_normalized_scores = einops.rearrange(torch.stack(list_normalized_scores),
+                                                    "time batch natom space  -> batch time natom space")
+
+        record_relative_coordinates = einops.rearrange(ys.flip(dims=(0,)),
+                                                       'times batch (natom space) -> batch times natom space',
+                                                       natom=self.number_of_atoms,
+                                                       space=self.spatial_dimension)
+
+        self.sample_trajectory_recorder.record_sde_solution(times=evaluation_times,
+                                                            sigmas=sigmas,
+                                                            relative_coordinates=record_relative_coordinates,
+                                                            normalized_scores=record_normalized_scores)

--- a/crystal_diffusion/models/score_fokker_planck_error.py
+++ b/crystal_diffusion/models/score_fokker_planck_error.py
@@ -1,0 +1,239 @@
+import einops
+import torch
+
+from crystal_diffusion.models.score_networks import ScoreNetwork
+from crystal_diffusion.namespace import (CARTESIAN_FORCES, NOISE,
+                                         NOISY_RELATIVE_COORDINATES, TIME,
+                                         UNIT_CELL)
+from crystal_diffusion.samplers.exploding_variance import ExplodingVariance
+from crystal_diffusion.samplers.variance_sampler import NoiseParameters
+
+
+class ScoreFokkerPlanckError(torch.nn.Module):
+    """Class to calculate the Score Fokker Planck Error.
+
+    This concept is defined in the paper:
+        "FP-Diffusion: Improving Score-based Diffusion Models by Enforcing  the Underlying Score Fokker-Planck Equation"
+
+    The Fokker-Planck equation, which is applicable to the time-dependent probability distribution, is generalized
+    to an ODE that the score should satisfy. The departure from satisfying this equation thus defines the FP error.
+
+    The score Fokker-Planck equation is defined as:
+
+        d S(x, t) / dt = 1/2 g(t)^2 nabla [ nabla.S(x,t) + |S(x,t)|^2]
+
+    where S(x, t) is the score.
+
+    The great advantage of this approach is that it only requires knowledge of the score (and its derivative), which
+    is the quantity we seek to learn.
+    """
+
+    def __init__(
+        self,
+        sigma_normalized_score_network: ScoreNetwork,
+        noise_parameters: NoiseParameters,
+    ):
+        """Init method."""
+        super().__init__()
+
+        self.exploding_variance = ExplodingVariance(noise_parameters)
+        self.sigma_normalized_score_network = sigma_normalized_score_network
+
+    def _get_scores(
+        self,
+        relative_coordinates: torch.Tensor,
+        times: torch.Tensor,
+        unit_cells: torch.Tensor,
+    ) -> torch.Tensor:
+        """Get Scores.
+
+        This method computes the un-normalized score, as defined by the sigma_normalized_score_network.
+
+        Args:
+            relative_coordinates : relative coordinates. Dimensions : [batch_size, number_of_atoms, spatial_dimension].
+            times : diffusion times. Dimensions : [batch_size, 1].
+            unit_cells : unit cells. Dimensions : [batch_size, spatial_dimension, spatial_dimension].
+
+        Returns:
+            scores: the scores for given input. Dimensions : [batch_size, number_of_atoms, spatial_dimension].
+        """
+        forces = torch.zeros_like(relative_coordinates)
+        sigmas = self.exploding_variance.get_sigma(times)
+
+        batch_size, natoms, spatial_dimension = relative_coordinates.shape
+
+        augmented_batch = {
+            NOISY_RELATIVE_COORDINATES: relative_coordinates,
+            TIME: times,
+            NOISE: sigmas,
+            UNIT_CELL: unit_cells,
+            CARTESIAN_FORCES: forces,
+        }
+
+        sigma_normalized_scores = self.sigma_normalized_score_network(
+            augmented_batch, conditional=False
+        )
+
+        broadcast_sigmas = einops.repeat(
+            sigmas,
+            "batch 1 -> batch natoms space",
+            natoms=natoms,
+            space=spatial_dimension,
+        )
+        scores = sigma_normalized_scores / broadcast_sigmas
+        return scores
+
+    def _get_scores_square_norm(
+        self,
+        relative_coordinates: torch.Tensor,
+        times: torch.Tensor,
+        unit_cells: torch.Tensor,
+    ) -> torch.Tensor:
+        """Get Scores square norm.
+
+        This method computes the square norm of the un-normalized score, as defined
+        by the sigma_normalized_score_network.
+
+        Args:
+            relative_coordinates : relative coordinates. Dimensions : [batch_size, number_of_atoms, spatial_dimension].
+            times : diffusion times. Dimensions : [batch_size, 1].
+            unit_cells : unit cells. Dimensions : [batch_size, spatial_dimension, spatial_dimension].
+
+        Returns:
+            scores_square_norm: |scores|^2. Dimension: [batch_size].
+        """
+        scores = self._get_scores(relative_coordinates, times, unit_cells)
+
+        flat_scores = einops.rearrange(
+            scores, "batch natoms spatial_dimension -> batch (natoms spatial_dimension)"
+        )
+
+        square_norms = (flat_scores**2).sum(dim=1)
+        return square_norms
+
+    def _get_score_time_derivative(
+        self,
+        relative_coordinates: torch.Tensor,
+        times: torch.Tensor,
+        unit_cells: torch.Tensor,
+    ) -> torch.Tensor:
+        """Compute the time derivative of the score using autograd."""
+        assert times.requires_grad, "The input times must require grads."
+
+        def scores_function(t_: torch.Tensor) -> torch.Tensor:
+            return self._get_scores(relative_coordinates, t_, unit_cells)
+
+        # The input variable, time, has dimension [batch_size, 1]
+        # The output of the function, the score, has dimension [batch_size, natoms, spatial_dimension]
+        # The jacobian will thus have dimensions [batch_size, natoms, spatial_dimension, batch_size, 1], that is,
+        # every output differentiated with respect to every input.
+        jacobian = torch.autograd.functional.jacobian(scores_function, times)
+
+        # Clearly, only "same batch element" is meaningful. We can squeeze out the needless last dimension in the time
+        batch_size = relative_coordinates.shape[0]
+        batch_idx = torch.arange(batch_size)
+        score_time_derivative = jacobian.squeeze(-1)[batch_idx, :, :, batch_idx]
+        return score_time_derivative
+
+    def _get_score_divergence(
+        self,
+        relative_coordinates: torch.Tensor,
+        times: torch.Tensor,
+        unit_cells: torch.Tensor,
+    ) -> torch.Tensor:
+        """Compute nabla . Score."""
+        assert (
+            relative_coordinates.requires_grad
+        ), "The input relative_coordinates must require grads."
+
+        def scores_function(x_):
+            return self._get_scores(x_, times, unit_cells)
+
+        # The input variable, x, has dimension [batch_size, natoms, spatial_dimension]
+        # The output of the function, the score, has dimension [batch_size, natoms, spatial_dimension]
+        # The jacobian will thus have dimensions
+        #   [batch_size, natoms, spatial_dimension, batch_size, natoms, spatial_dimension]
+        # every output differentiated with respect to every input.
+        jacobian = torch.autograd.functional.jacobian(
+            scores_function, relative_coordinates, create_graph=True
+        )
+
+        flat_jacobian = einops.rearrange(
+            jacobian,
+            "batch1 natoms1 space1 batch2 natoms2 space2 -> batch1 batch2 (natoms1 space1) (natoms2 space2)",
+        )
+
+        # Clearly, only "same batch element" is meaningful. We can squeeze out the needless last dimension in the time
+        batch_size = relative_coordinates.shape[0]
+        batch_idx = torch.arange(batch_size)
+        batch_flat_jacobian = flat_jacobian[batch_idx, batch_idx]
+
+        divergence = einops.einsum(batch_flat_jacobian, "batch f f -> batch")
+
+        return divergence
+
+    def _get_gradient_term(
+        self,
+        relative_coordinates: torch.Tensor,
+        times: torch.Tensor,
+        unit_cells: torch.Tensor,
+    ) -> torch.Tensor:
+        """Compute nabla [ nabla.Score + |Score|^2]."""
+        assert (
+            relative_coordinates.requires_grad
+        ), "The input relative_coordinates must require grads."
+
+        def term_function(x_):
+            # The "term" is nabla . s + |s|^2
+            return (self._get_score_divergence(x_, times, unit_cells)
+                    + self._get_scores_square_norm(x_, times, unit_cells))
+
+        # The input variable, x, has dimension [batch_size, natoms, spatial_dimension]
+        # The output of the function, the term_function, has dimension [batch_size]
+        # The jacobian will thus have dimensions
+        #   [batch_size, batch_size, natoms, spatial_dimension]
+        # every output differentiated with respect to every input.
+        jacobian = torch.autograd.functional.jacobian(
+            term_function, relative_coordinates
+        )
+
+        # Clearly, only "same batch element" is meaningful. We can squeeze out the needless last dimension in the time
+        batch_size = relative_coordinates.shape[0]
+        batch_idx = torch.arange(batch_size)
+        gradient_term = jacobian[batch_idx, batch_idx]
+        return gradient_term
+
+    def get_score_fokker_planck_error(
+        self,
+        relative_coordinates: torch.Tensor,
+        times: torch.Tensor,
+        unit_cells: torch.Tensor,
+    ) -> torch.Tensor:
+        """Get Score Fokker-Planck Error.
+
+        Args:
+            relative_coordinates : relative coordinates. Dimensions : [batch_size, number_of_atoms, spatial_dimension].
+            times : diffusion times. Dimensions : [batch_size, 1].
+            unit_cells : unit cells. Dimensions : [batch_size, spatial_dimension, spatial_dimension].
+
+        Returns:
+            FP_error: how much the score Fokker-Planck equation is violated. Dimensions : [batch_size].
+        """
+        batch_size, natoms, spatial_dimension = relative_coordinates.shape
+        t = torch.tensor(times, requires_grad=True)
+        d_score_dt = self._get_score_time_derivative(
+            relative_coordinates, t, unit_cells
+        )
+
+        x = torch.tensor(relative_coordinates, requires_grad=True)
+        gradient_term = self._get_gradient_term(x, times, unit_cells)
+
+        time_prefactor = einops.repeat(
+            0.5 * self.exploding_variance.get_g_squared(times),
+            "batch 1 -> batch natoms spatial_dimension",
+            natoms=natoms,
+            spatial_dimension=spatial_dimension,
+        )
+
+        fp_errors = d_score_dt - time_prefactor * gradient_term
+        return fp_errors

--- a/crystal_diffusion/samplers/exploding_variance.py
+++ b/crystal_diffusion/samplers/exploding_variance.py
@@ -1,0 +1,64 @@
+import torch
+
+from crystal_diffusion.samplers.variance_sampler import NoiseParameters
+
+
+class ExplodingVariance(torch.nn.Module):
+    """Exploding Variance.
+
+    This class is responsible for calculating the various quantities related  to the diffusion variance.
+    This implementation will use "exploding variance" scheme.
+    """
+
+    def __init__(self, noise_parameters: NoiseParameters):
+        """Init method.
+
+        Args:
+            noise_parameters: parameters that define the noise schedule.
+        """
+        super(ExplodingVariance, self).__init__()
+
+        self.sigma_min = torch.nn.Parameter(torch.tensor(noise_parameters.sigma_min))
+        self.sigma_max = torch.nn.Parameter(torch.tensor(noise_parameters.sigma_max))
+
+        self.ratio = self.sigma_max / self.sigma_min
+        self.log_ratio = torch.log(self.sigma_max / self.sigma_min)
+
+    def get_sigma(self, times: torch.Tensor) -> torch.Tensor:
+        """Get sigma.
+
+        Compute the exploding variance value of sigma(t).
+
+        Args:
+            times : diffusion times.
+
+        Returns:
+            sigmas: the standard deviation in the exploding variance scheme.
+        """
+        return self.sigma_min * self.ratio ** times
+
+    def get_sigma_time_derivative(self, times: torch.Tensor) -> torch.Tensor:
+        """Get sigma time derivative.
+
+        Compute the analytical time derivative of sigma.
+
+        Args:
+            times : diffusion times.
+
+        Returns:
+            sigma_dot : time derivative of sigma(t).
+        """
+        return self.log_ratio * self.get_sigma(times)
+
+    def get_g_squared(self, times: torch.Tensor) -> torch.Tensor:
+        """Get g squared.
+
+        Compute g(t)^2 = d sigma(t)^2 / dt
+
+        Args:
+            times : diffusion times.
+
+        Returns:
+            g_squared: g(t)^2
+        """
+        return 2.0 * self.get_sigma(times) * self.get_sigma_time_derivative(times)

--- a/crystal_diffusion/utils/sample_trajectory.py
+++ b/crystal_diffusion/utils/sample_trajectory.py
@@ -65,6 +65,32 @@ class ODESampleTrajectory(SampleTrajectory):
         return standardized_data
 
 
+class SDESampleTrajectory(SampleTrajectory):
+    """SDE Sample Trajectory.
+
+    This class aims to record all details of the SDE diffusion sampling process. The goal is to produce
+    an artifact that can then be analyzed off-line.
+    """
+
+    def record_sde_solution(self, times: torch.Tensor, sigmas: torch.Tensor,
+                            relative_coordinates: torch.Tensor, normalized_scores: torch.Tensor):
+        """Record ODE solution information."""
+        self.data['time'].append(times)
+        self.data['sigma'].append(sigmas)
+        self.data['relative_coordinates'].append(relative_coordinates)
+        self.data['normalized_scores'].append(normalized_scores)
+
+    def standardize_data(self, data: Dict[AnyStr, Any]) -> Dict[AnyStr, Any]:
+        """Method to transform the recorded data to a standard form."""
+        standardized_data = dict(unit_cell=data['unit_cell'],
+                                 time=data['time'][0],
+                                 sigma=data['sigma'][0],
+                                 relative_coordinates=data['relative_coordinates'][0],
+                                 normalized_scores=data['normalized_scores'][0],
+                                 )
+        return standardized_data
+
+
 class NoOpODESampleTrajectory(ODESampleTrajectory):
     """A sample trajectory object that performs no operation."""
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,4 @@ pykeops==2.2.3
 comet_ml
 einops==0.8.0
 torchode==0.2.0
+torchsde==0.2.6

--- a/sanity_checks/generators/__init__.py
+++ b/sanity_checks/generators/__init__.py
@@ -1,0 +1,3 @@
+from pathlib import Path
+
+GENERATOR_SANITY_CHECK_DIRECTORY = Path(__file__).parent

--- a/sanity_checks/generators/sde_generator_sanity_check.py
+++ b/sanity_checks/generators/sde_generator_sanity_check.py
@@ -1,0 +1,151 @@
+"""SDE Generator Sanity Check.
+
+Check that the SDE generator can solve simple SDEs in 1 dimension with the analytical score as the source of drift.
+"""
+
+import einops
+import numpy as np
+import torch
+from matplotlib import pyplot as plt
+
+from crystal_diffusion.analysis import PLEASANT_FIG_SIZE, PLOT_STYLE_PATH
+from crystal_diffusion.analysis.analytic_score.utils import get_exact_samples
+from crystal_diffusion.generators.sde_position_generator import (
+    ExplodingVarianceSDEPositionGenerator, SDESamplingParameters)
+from crystal_diffusion.models.score_networks.analytical_score_network import (
+    AnalyticalScoreNetworkParameters, TargetScoreBasedAnalyticalScoreNetwork)
+from crystal_diffusion.samplers.variance_sampler import NoiseParameters
+from crystal_diffusion.utils.basis_transformations import \
+    map_relative_coordinates_to_unit_cell
+from sanity_checks.generators import GENERATOR_SANITY_CHECK_DIRECTORY
+
+plt.style.use(PLOT_STYLE_PATH)
+
+
+class DisplacementCalculator:
+    """Calculate the displacement distribution."""
+
+    def __init__(self, equilibrium_relative_coordinates: torch.Tensor):
+        """Init method."""
+        self.equilibrium_relative_coordinates = equilibrium_relative_coordinates
+
+    def compute_displacements(self, batch_relative_coordinates: torch.Tensor) -> np.ndarray:
+        """Compute displacements."""
+        return (batch_relative_coordinates - equilibrium_relative_coordinates).flatten()
+
+
+def generate_exact_samples(equilibrium_relative_coordinates: torch.Tensor, sigma_d: float, number_of_samples: int):
+    """Generate Gaussian samples about the equilibrium relative coordinates."""
+    variance_parameter = sigma_d ** 2
+
+    number_of_atoms, spatial_dimension = equilibrium_relative_coordinates.shape
+    nd = number_of_atoms * spatial_dimension
+
+    inverse_covariance = torch.diag(torch.ones(nd)) / variance_parameter
+    inverse_covariance = inverse_covariance.reshape(number_of_atoms, spatial_dimension,
+                                                    number_of_atoms, spatial_dimension)
+
+    exact_samples = get_exact_samples(equilibrium_relative_coordinates, inverse_covariance, number_of_samples)
+    exact_samples = map_relative_coordinates_to_unit_cell(exact_samples)
+    return exact_samples
+
+
+device = torch.device('cpu')
+
+number_of_atoms = 1
+spatial_dimension = 1
+kmax = 8
+acell = 1.
+cell_dimensions = [acell]
+
+output_dir = GENERATOR_SANITY_CHECK_DIRECTORY / "figures"
+output_dir.mkdir(exist_ok=True)
+
+number_of_samples = 1000
+
+list_sigma_d = [0.1, 0.01, 0.001]
+sigma_min = 0.001
+total_time_steps = 101
+
+if __name__ == '__main__':
+
+    unit_cell = torch.diag(torch.tensor(cell_dimensions))
+    batched_unit_cells = einops.repeat(unit_cell, "d1 d2 -> b d1 d2", b=number_of_samples)
+
+    equilibrium_relative_coordinates = torch.tensor([[0.5]])
+    displacement_calculator = DisplacementCalculator(equilibrium_relative_coordinates=equilibrium_relative_coordinates)
+
+    for sigma_d in list_sigma_d:
+
+        exact_samples = generate_exact_samples(equilibrium_relative_coordinates,
+                                               sigma_d=sigma_d,
+                                               number_of_samples=number_of_samples)
+
+        exact_samples_displacements = displacement_calculator.compute_displacements(exact_samples)
+
+        score_network_parameters = AnalyticalScoreNetworkParameters(
+            number_of_atoms=number_of_atoms,
+            spatial_dimension=spatial_dimension,
+            use_permutation_invariance=False,
+            kmax=kmax,
+            equilibrium_relative_coordinates=equilibrium_relative_coordinates,
+            variance_parameter=sigma_d**2)
+
+        sigma_normalized_score_network = TargetScoreBasedAnalyticalScoreNetwork(score_network_parameters)
+
+        sampling_parameters = SDESamplingParameters(method='euler',
+                                                    adaptative=False,
+                                                    absolute_solver_tolerance=1.0e-7,
+                                                    relative_solver_tolerance=1.0e-5,
+                                                    number_of_atoms=number_of_atoms,
+                                                    spatial_dimension=spatial_dimension,
+                                                    number_of_samples=number_of_samples,
+                                                    sample_batchsize=number_of_samples,
+                                                    cell_dimensions=cell_dimensions,
+                                                    record_samples=True)
+
+        noise_parameters = NoiseParameters(total_time_steps=total_time_steps,
+                                           sigma_min=sigma_min,
+                                           sigma_max=0.5)
+
+        generator = ExplodingVarianceSDEPositionGenerator(noise_parameters=noise_parameters,
+                                                          sampling_parameters=sampling_parameters,
+                                                          sigma_normalized_score_network=sigma_normalized_score_network)
+
+        generated_samples = generator.sample(number_of_samples,
+                                             device=device,
+                                             unit_cell=batched_unit_cells)
+
+        sampled_x = generated_samples[:, 0, 0]
+
+        trajectory_data = generator.sample_trajectory_recorder.standardize_data(
+            generator.sample_trajectory_recorder.data)
+
+        times = trajectory_data['time']
+        x = trajectory_data['relative_coordinates'][:, :, 0, 0]
+
+        fig = plt.figure(figsize=PLEASANT_FIG_SIZE)
+        fig.suptitle("1 Atom in 1D, Analytical Score, SDE solver"
+                     f"\n $\\sigma_d$ = {sigma_d:4.3f}, time steps = {total_time_steps}")
+        ax1 = fig.add_subplot(121)
+        ax1.set_title("Subset of Sampling Trajectories")
+        for i in range(50):
+            ax1.plot(times, x[i, :], '-', color='gray', alpha=0.5)
+        ax1.set_xlim(1, 0)
+        ax1.set_xlabel('Diffusion Time')
+        ax1.set_ylabel('$x(t)$')
+
+        generated_samples_displacements = displacement_calculator.compute_displacements(generated_samples)
+
+        ax2 = fig.add_subplot(122)
+        ax2.set_title("Distribution of Displacements")
+
+        common_params = dict(density=True, bins=101, histtype="stepfilled", alpha=0.25)
+        ax2.hist(exact_samples_displacements, **common_params, label='Exact Samples Displacements', color='green')
+        ax2.hist(generated_samples_displacements, **common_params, label='Generated Samples Displacements', color='red')
+
+        ax2.set_xlabel('$x - x_0$')
+        ax2.set_ylabel('Density')
+        ax2.legend(loc='upper right', fancybox=True, shadow=True, ncol=1, fontsize=8)
+        fig.tight_layout()
+        fig.savefig(output_dir / f"sde_solution_sigma_d={sigma_d}.png")

--- a/tests/generators/conftest.py
+++ b/tests/generators/conftest.py
@@ -39,5 +39,9 @@ class BaseTestGenerator:
         return torch.diag(torch.Tensor([unit_cell_size] * spatial_dimension)).repeat(number_of_samples, 1, 1)
 
     @pytest.fixture()
+    def cell_dimensions(self, unit_cell_size, spatial_dimension):
+        return spatial_dimension * [unit_cell_size]
+
+    @pytest.fixture()
     def sigma_normalized_score_network(self, spatial_dimension):
         return FakeScoreNetwork(ScoreNetworkParameters(architecture='dummy', spatial_dimension=spatial_dimension))

--- a/tests/generators/conftest.py
+++ b/tests/generators/conftest.py
@@ -1,0 +1,43 @@
+from typing import AnyStr, Dict
+
+import pytest
+import torch
+
+from crystal_diffusion.models.score_networks import (ScoreNetwork,
+                                                     ScoreNetworkParameters)
+from crystal_diffusion.namespace import NOISY_RELATIVE_COORDINATES
+
+
+class FakeScoreNetwork(ScoreNetwork):
+    """A fake, smooth score network for the ODE solver."""
+
+    def _forward_unchecked(self, batch: Dict[AnyStr, torch.Tensor], conditional: bool = False) -> torch.Tensor:
+        return batch[NOISY_RELATIVE_COORDINATES]
+
+
+class BaseTestGenerator:
+    """A base class that contains common test fixtures useful for testing generators."""
+
+    @pytest.fixture()
+    def unit_cell_size(self):
+        return 10
+
+    @pytest.fixture()
+    def number_of_atoms(self):
+        return 8
+
+    @pytest.fixture()
+    def number_of_samples(self):
+        return 5
+
+    @pytest.fixture(params=[2, 3])
+    def spatial_dimension(self, request):
+        return request.param
+
+    @pytest.fixture()
+    def unit_cell_sample(self, unit_cell_size, spatial_dimension, number_of_samples):
+        return torch.diag(torch.Tensor([unit_cell_size] * spatial_dimension)).repeat(number_of_samples, 1, 1)
+
+    @pytest.fixture()
+    def sigma_normalized_score_network(self, spatial_dimension):
+        return FakeScoreNetwork(ScoreNetworkParameters(architecture='dummy', spatial_dimension=spatial_dimension))

--- a/tests/generators/test_constrained_langevin_generator.py
+++ b/tests/generators/test_constrained_langevin_generator.py
@@ -15,13 +15,13 @@ class TestConstrainedLangevinGenerator(TestLangevinGenerator):
         return torch.rand(number_of_constraints, spatial_dimension).numpy()
 
     @pytest.fixture()
-    def sampling_parameters(self, number_of_atoms, spatial_dimension, number_of_samples,
+    def sampling_parameters(self, number_of_atoms, spatial_dimension, number_of_samples, cell_dimensions,
                             number_of_corrector_steps, unit_cell_size, constrained_relative_coordinates):
         sampling_parameters = ConstrainedLangevinGeneratorParameters(
             number_of_corrector_steps=number_of_corrector_steps,
             number_of_atoms=number_of_atoms,
             number_of_samples=number_of_samples,
-            cell_dimensions=spatial_dimension * [unit_cell_size],
+            cell_dimensions=cell_dimensions,
             spatial_dimension=spatial_dimension,
             constrained_relative_coordinates=constrained_relative_coordinates)
 

--- a/tests/generators/test_langevin_generator.py
+++ b/tests/generators/test_langevin_generator.py
@@ -4,15 +4,14 @@ import torch
 from crystal_diffusion.generators.langevin_generator import LangevinGenerator
 from crystal_diffusion.generators.predictor_corrector_position_generator import \
     PredictorCorrectorSamplingParameters
-from crystal_diffusion.models.score_networks.mlp_score_network import (
-    MLPScoreNetwork, MLPScoreNetworkParameters)
 from crystal_diffusion.samplers.variance_sampler import (
     ExplodingVarianceSampler, NoiseParameters)
 from crystal_diffusion.utils.basis_transformations import \
     map_relative_coordinates_to_unit_cell
+from tests.generators.conftest import BaseTestGenerator
 
 
-class TestLangevinGenerator:
+class TestLangevinGenerator(BaseTestGenerator):
 
     @pytest.fixture(params=[0, 1, 2])
     def number_of_corrector_steps(self, request):
@@ -21,33 +20,6 @@ class TestLangevinGenerator:
     @pytest.fixture(params=[1, 5, 10])
     def total_time_steps(self, request):
         return request.param
-
-    @pytest.fixture(params=[2, 3])
-    def spatial_dimension(self, request):
-        return request.param
-
-    @pytest.fixture()
-    def number_of_atoms(self):
-        return 8
-
-    @pytest.fixture()
-    def number_of_samples(self):
-        return 8
-
-    @pytest.fixture()
-    def unit_cell_size(self):
-        return 10
-
-    @pytest.fixture()
-    def sigma_normalized_score_network(self, number_of_atoms, spatial_dimension, device):
-        hyper_params = MLPScoreNetworkParameters(
-            spatial_dimension=spatial_dimension,
-            number_of_atoms=number_of_atoms,
-            n_hidden_dimensions=3,
-            embedding_dimensions_size=8,
-            hidden_dimensions_size=16
-        )
-        return MLPScoreNetwork(hyper_params).to(device)
 
     @pytest.fixture()
     def noise_parameters(self, total_time_steps):
@@ -75,10 +47,6 @@ class TestLangevinGenerator:
                                       sigma_normalized_score_network=sigma_normalized_score_network)
 
         return generator
-
-    @pytest.fixture()
-    def unit_cell_sample(self, unit_cell_size, spatial_dimension, number_of_samples, device):
-        return torch.diag(torch.Tensor([unit_cell_size] * spatial_dimension)).repeat(number_of_samples, 1, 1).to(device)
 
     def test_smoke_sample(self, pc_generator, device, number_of_samples, unit_cell_sample):
         # Just a smoke test that we can sample without crashing.

--- a/tests/generators/test_langevin_generator.py
+++ b/tests/generators/test_langevin_generator.py
@@ -30,12 +30,12 @@ class TestLangevinGenerator(BaseTestGenerator):
         return noise_parameters
 
     @pytest.fixture()
-    def sampling_parameters(self, number_of_atoms, spatial_dimension, number_of_samples,
+    def sampling_parameters(self, number_of_atoms, spatial_dimension, cell_dimensions, number_of_samples,
                             number_of_corrector_steps, unit_cell_size):
         sampling_parameters = PredictorCorrectorSamplingParameters(number_of_corrector_steps=number_of_corrector_steps,
                                                                    number_of_atoms=number_of_atoms,
                                                                    number_of_samples=number_of_samples,
-                                                                   cell_dimensions=spatial_dimension * [unit_cell_size],
+                                                                   cell_dimensions=cell_dimensions,
                                                                    spatial_dimension=spatial_dimension)
 
         return sampling_parameters

--- a/tests/generators/test_ode_position_generator.py
+++ b/tests/generators/test_ode_position_generator.py
@@ -1,34 +1,18 @@
-from typing import AnyStr, Dict
-
 import pytest
 import torch
 
 from crystal_diffusion.generators.ode_position_generator import (
     ExplodingVarianceODEPositionGenerator, ODESamplingParameters)
-from crystal_diffusion.models.score_networks.score_network import (
-    ScoreNetwork, ScoreNetworkParameters)
-from crystal_diffusion.namespace import NOISY_RELATIVE_COORDINATES
 from crystal_diffusion.samplers.variance_sampler import (
     ExplodingVarianceSampler, NoiseParameters)
-
-
-class FakeScoreNetwork(ScoreNetwork):
-    """A fake, smooth score network for the ODE solver."""
-
-    def _forward_unchecked(self, batch: Dict[AnyStr, torch.Tensor], conditional: bool = False) -> torch.Tensor:
-        return batch[NOISY_RELATIVE_COORDINATES]
+from tests.generators.conftest import BaseTestGenerator
 
 
 @pytest.mark.parametrize("total_time_steps", [2, 5, 10])
-@pytest.mark.parametrize("spatial_dimension", [2, 3])
-@pytest.mark.parametrize("number_of_atoms", [8])
 @pytest.mark.parametrize("sigma_min", [0.15])
 @pytest.mark.parametrize("record_samples", [False, True])
 @pytest.mark.parametrize("number_of_samples", [8])
-class TestExplodingVarianceODEPositionGenerator:
-    @pytest.fixture()
-    def sigma_normalized_score_network(self, spatial_dimension):
-        return FakeScoreNetwork(ScoreNetworkParameters(architecture='dummy', spatial_dimension=spatial_dimension))
+class TestExplodingVarianceODEPositionGenerator(BaseTestGenerator):
 
     @pytest.fixture()
     def noise_parameters(self, total_time_steps, sigma_min):
@@ -50,11 +34,6 @@ class TestExplodingVarianceODEPositionGenerator:
                                                           sigma_normalized_score_network=sigma_normalized_score_network)
 
         return generator
-
-    @pytest.fixture()
-    def unit_cell_sample(self, spatial_dimension, number_of_samples):
-        unit_cell_size = 10.
-        return torch.diag(torch.Tensor([unit_cell_size] * spatial_dimension)).repeat(number_of_samples, 1, 1)
 
     def test_get_exploding_variance_sigma(self, ode_generator, noise_parameters):
         times = ExplodingVarianceSampler._get_time_array(noise_parameters)

--- a/tests/generators/test_ode_position_generator.py
+++ b/tests/generators/test_ode_position_generator.py
@@ -19,11 +19,12 @@ class TestExplodingVarianceODEPositionGenerator(BaseTestGenerator):
         return NoiseParameters(total_time_steps=total_time_steps, time_delta=0., sigma_min=sigma_min)
 
     @pytest.fixture()
-    def sampling_parameters(self, number_of_atoms, spatial_dimension, number_of_samples, record_samples):
+    def sampling_parameters(self, number_of_atoms, spatial_dimension, cell_dimensions,
+                            number_of_samples, record_samples):
         sampling_parameters = ODESamplingParameters(number_of_atoms=number_of_atoms,
                                                     spatial_dimension=spatial_dimension,
                                                     number_of_samples=number_of_samples,
-                                                    cell_dimensions=spatial_dimension * [10],
+                                                    cell_dimensions=cell_dimensions,
                                                     record_samples=record_samples)
         return sampling_parameters
 

--- a/tests/generators/test_predictor_corrector_position_generator.py
+++ b/tests/generators/test_predictor_corrector_position_generator.py
@@ -5,6 +5,7 @@ from crystal_diffusion.generators.predictor_corrector_position_generator import 
     PredictorCorrectorPositionGenerator
 from crystal_diffusion.utils.basis_transformations import \
     map_relative_coordinates_to_unit_cell
+from tests.generators.conftest import BaseTestGenerator
 
 
 class FakePCGenerator(PredictorCorrectorPositionGenerator):
@@ -32,13 +33,9 @@ class FakePCGenerator(PredictorCorrectorPositionGenerator):
         return 0.56 * x_i + 7.89 + i / 117.0
 
 
-@pytest.mark.parametrize("number_of_samples", [4])
-@pytest.mark.parametrize("number_of_atoms", [8])
-@pytest.mark.parametrize("spatial_dimension", [2, 3])
 @pytest.mark.parametrize("number_of_discretization_steps", [1, 5, 10])
 @pytest.mark.parametrize("number_of_corrector_steps", [0, 1, 2])
-@pytest.mark.parametrize("unit_cell_size", [10])
-class TestPredictorCorrectorPositionGenerator:
+class TestPredictorCorrectorPositionGenerator(BaseTestGenerator):
     @pytest.fixture(scope="class", autouse=True)
     def set_random_seed(self):
         torch.manual_seed(1234567)
@@ -55,10 +52,6 @@ class TestPredictorCorrectorPositionGenerator:
             number_of_discretization_steps, number_of_corrector_steps, spatial_dimension, initial_sample
         )
         return generator
-
-    @pytest.fixture()
-    def unit_cell_sample(self, unit_cell_size, spatial_dimension, number_of_samples):
-        return torch.diag(torch.Tensor([unit_cell_size] * spatial_dimension)).repeat(number_of_samples, 1, 1)
 
     @pytest.fixture
     def expected_samples(

--- a/tests/generators/test_sde_position_generator.py
+++ b/tests/generators/test_sde_position_generator.py
@@ -1,0 +1,89 @@
+import pytest
+import torch
+
+from crystal_diffusion.generators.sde_position_generator import (
+    SDE, ExplodingVarianceSDEPositionGenerator, SDESamplingParameters)
+from crystal_diffusion.samplers.variance_sampler import (
+    ExplodingVarianceSampler, NoiseParameters)
+from tests.generators.conftest import BaseTestGenerator
+
+
+@pytest.mark.parametrize("total_time_steps", [5, 10])
+@pytest.mark.parametrize("sigma_min", [0.15])
+@pytest.mark.parametrize("record_samples", [False, True])
+class TestExplodingVarianceSDEPositionGenerator(BaseTestGenerator):
+    @pytest.fixture()
+    def initial_diffusion_time(self):
+        return torch.tensor(0.)
+
+    @pytest.fixture()
+    def final_diffusion_time(self):
+        return torch.tensor(1.)
+
+    @pytest.fixture()
+    def noise_parameters(self, total_time_steps, sigma_min):
+        return NoiseParameters(total_time_steps=total_time_steps, time_delta=0., sigma_min=sigma_min)
+
+    @pytest.fixture()
+    def sampling_parameters(self, number_of_atoms, spatial_dimension, cell_dimensions,
+                            number_of_samples, record_samples):
+        sampling_parameters = SDESamplingParameters(number_of_atoms=number_of_atoms,
+                                                    spatial_dimension=spatial_dimension,
+                                                    number_of_samples=number_of_samples,
+                                                    cell_dimensions=cell_dimensions,
+                                                    record_samples=record_samples)
+        return sampling_parameters
+
+    @pytest.fixture()
+    def sde(self, noise_parameters, sampling_parameters, sigma_normalized_score_network, unit_cell_sample,
+            initial_diffusion_time, final_diffusion_time):
+        sde = SDE(noise_parameters=noise_parameters,
+                  sampling_parameters=sampling_parameters,
+                  sigma_normalized_score_network=sigma_normalized_score_network,
+                  unit_cells=unit_cell_sample,
+                  initial_diffusion_time=initial_diffusion_time,
+                  final_diffusion_time=final_diffusion_time)
+        return sde
+
+    def test_sde_get_diffusion_time(self, sde, initial_diffusion_time, final_diffusion_time):
+
+        diffusion_time = (initial_diffusion_time + torch.rand(1) * (final_diffusion_time - initial_diffusion_time))[0]
+
+        sde_time = final_diffusion_time - diffusion_time
+
+        computed_diffusion_time = sde._get_diffusion_time(sde_time)
+
+        torch.testing.assert_close(computed_diffusion_time, diffusion_time)
+
+    def test_sde_g_squared(self, sde, noise_parameters, initial_diffusion_time, final_diffusion_time):
+
+        time_array = initial_diffusion_time + torch.rand(1) * (final_diffusion_time - initial_diffusion_time)
+
+        sigma = ExplodingVarianceSampler._create_sigma_array(noise_parameters=noise_parameters,
+                                                             time_array=time_array)[0]
+
+        expected_g_squared = (2. * sigma**2
+                              * torch.log(torch.tensor(noise_parameters.sigma_max / noise_parameters.sigma_min)))
+
+        diffusion_time = time_array[0]
+
+        computed_g_squared = sde._get_diffusion_coefficient_g_squared(diffusion_time)
+
+        torch.testing.assert_close(computed_g_squared, expected_g_squared)
+
+    @pytest.fixture()
+    def sde_generator(self, noise_parameters, sampling_parameters, sigma_normalized_score_network):
+        generator = ExplodingVarianceSDEPositionGenerator(noise_parameters=noise_parameters,
+                                                          sampling_parameters=sampling_parameters,
+                                                          sigma_normalized_score_network=sigma_normalized_score_network)
+        return generator
+
+    def test_smoke_sample(self, sde_generator, device, number_of_samples,
+                          number_of_atoms, spatial_dimension, unit_cell_sample):
+        # Just a smoke test that we can sample without crashing.
+        relative_coordinates = sde_generator.sample(number_of_samples, device, unit_cell_sample)
+
+        assert relative_coordinates.shape == (number_of_samples, number_of_atoms, spatial_dimension)
+
+        assert relative_coordinates.min() >= 0.
+        assert relative_coordinates.max() < 1.

--- a/tests/models/test_score_fokker_planck_error.py
+++ b/tests/models/test_score_fokker_planck_error.py
@@ -1,0 +1,257 @@
+import einops
+import pytest
+import torch
+
+from crystal_diffusion.models.score_fokker_planck_error import \
+    ScoreFokkerPlanckError
+from crystal_diffusion.models.score_networks.analytical_score_network import (
+    AnalyticalScoreNetworkParameters, TargetScoreBasedAnalyticalScoreNetwork)
+from crystal_diffusion.namespace import (NOISE, NOISY_RELATIVE_COORDINATES,
+                                         TIME, UNIT_CELL)
+from crystal_diffusion.samplers.exploding_variance import ExplodingVariance
+from crystal_diffusion.samplers.variance_sampler import NoiseParameters
+
+
+class TestScoreFokkerPlanckError:
+    @pytest.fixture(scope="class", autouse=True)
+    def set_default_type_to_float64(self):
+        torch.set_default_dtype(torch.float64)
+        yield
+        # this returns the default type to float32 at the end of all tests in this class in order
+        # to not affect other tests.
+        torch.set_default_dtype(torch.float32)
+
+    @pytest.fixture(scope="class", autouse=True)
+    def set_random_seed(self):
+        torch.manual_seed(23423423)
+
+    @pytest.fixture
+    def batch_size(self):
+        return 4
+
+    @pytest.fixture
+    def kmax(self):
+        # kmax has to be fairly large for the comparison test between the analytical score and the target based
+        # analytical score to pass.
+        return 8
+
+    @pytest.fixture(params=[1, 2, 3])
+    def spatial_dimension(self, request):
+        return request.param
+
+    @pytest.fixture(params=[4, 8])
+    def number_of_atoms(self, request):
+        return request.param
+
+    @pytest.fixture
+    def relative_coordinates(self, batch_size, number_of_atoms, spatial_dimension):
+        return torch.rand(batch_size, number_of_atoms, spatial_dimension)
+
+    @pytest.fixture
+    def times(self, batch_size):
+        times = torch.rand(batch_size, 1)
+        return times
+
+    @pytest.fixture
+    def unit_cells(self, batch_size, spatial_dimension):
+        return torch.rand(batch_size, spatial_dimension, spatial_dimension)
+
+    @pytest.fixture()
+    def score_network_parameters(self, number_of_atoms, spatial_dimension, kmax):
+        equilibrium_relative_coordinates = torch.rand(
+            number_of_atoms, spatial_dimension
+        )
+        hyper_params = AnalyticalScoreNetworkParameters(
+            number_of_atoms=number_of_atoms,
+            spatial_dimension=spatial_dimension,
+            kmax=kmax,
+            equilibrium_relative_coordinates=equilibrium_relative_coordinates,
+            variance_parameter=0.1,
+            use_permutation_invariance=False,
+        )
+        return hyper_params
+
+    @pytest.fixture()
+    def noise_parameters(self):
+        return NoiseParameters(total_time_steps=10, sigma_min=0.1, sigma_max=0.5)
+
+    @pytest.fixture()
+    def batch(self, relative_coordinates, times, unit_cells, noise_parameters):
+        return {
+            NOISY_RELATIVE_COORDINATES: relative_coordinates,
+            TIME: times,
+            NOISE: ExplodingVariance(noise_parameters).get_sigma(times),
+            UNIT_CELL: unit_cells,
+        }
+
+    @pytest.fixture()
+    def sigma_normalized_score_network(self, score_network_parameters):
+        return TargetScoreBasedAnalyticalScoreNetwork(score_network_parameters)
+
+    @pytest.fixture
+    def expected_scores(self, sigma_normalized_score_network, batch):
+        sigma_normalized_scores = sigma_normalized_score_network(batch)
+        _, natoms, spatial_dimension = sigma_normalized_scores.shape
+        sigmas = batch[NOISE]
+        scores = sigma_normalized_scores / einops.repeat(
+            sigmas, "b 1 -> b n s", n=natoms, s=spatial_dimension
+        )
+        return scores
+
+    @pytest.fixture
+    def score_fokker_planck_error(
+        self, sigma_normalized_score_network, noise_parameters
+    ):
+        return ScoreFokkerPlanckError(sigma_normalized_score_network, noise_parameters)
+
+    def test_get_score(
+        self,
+        score_fokker_planck_error,
+        relative_coordinates,
+        times,
+        unit_cells,
+        expected_scores,
+    ):
+        computed_scores = score_fokker_planck_error._get_scores(
+            relative_coordinates, times, unit_cells
+        )
+
+        torch.testing.assert_close(computed_scores, expected_scores)
+
+    def test_get_score_time_derivative(
+        self,
+        score_fokker_planck_error,
+        relative_coordinates,
+        times,
+        unit_cells,
+        expected_scores,
+    ):
+        # Finite difference approximation
+        h = 1e-8 * torch.ones_like(times)
+        scores_hp = score_fokker_planck_error._get_scores(
+            relative_coordinates, times + h, unit_cells
+        )
+        scores_hm = score_fokker_planck_error._get_scores(
+            relative_coordinates, times - h, unit_cells
+        )
+
+        batch_size, natoms, spatial_dimension = scores_hp.shape
+        denominator = einops.repeat(
+            2 * h, "b 1 -> b n s", n=natoms, s=spatial_dimension
+        )
+        expected_score_time_derivative = (scores_hp - scores_hm) / denominator
+
+        t = torch.tensor(times, requires_grad=True)
+        computed_score_time_derivative = (
+            score_fokker_planck_error._get_score_time_derivative(
+                relative_coordinates, t, unit_cells
+            )
+        )
+        torch.testing.assert_close(
+            computed_score_time_derivative, expected_score_time_derivative
+        )
+
+    def test_get_score_divergence(
+        self,
+        score_fokker_planck_error,
+        relative_coordinates,
+        times,
+        unit_cells,
+        expected_scores,
+    ):
+        # Finite difference approximation
+        epsilon = 1e-8
+
+        batch_size, natoms, spatial_dimension = relative_coordinates.shape
+
+        expected_score_divergence = torch.zeros(batch_size)
+
+        for atom_idx in range(natoms):
+            for space_idx in range(spatial_dimension):
+                dx = torch.zeros_like(relative_coordinates)
+                dx[:, atom_idx, space_idx] = epsilon
+                scores_hp = score_fokker_planck_error._get_scores(
+                    relative_coordinates + dx, times, unit_cells
+                )
+                scores_hm = score_fokker_planck_error._get_scores(
+                    relative_coordinates - dx, times, unit_cells
+                )
+                dscore = (
+                    scores_hp[:, atom_idx, space_idx]
+                    - scores_hm[:, atom_idx, space_idx]
+                )
+
+                expected_score_divergence += dscore / (2.0 * epsilon)
+
+        x = torch.tensor(relative_coordinates, requires_grad=True)
+        computed_score_divergence = score_fokker_planck_error._get_score_divergence(
+            x, times, unit_cells
+        )
+
+        torch.testing.assert_close(computed_score_divergence, expected_score_divergence)
+
+    def test_get_scores_square_norm(
+        self, score_fokker_planck_error, relative_coordinates, times, unit_cells
+    ):
+        scores = score_fokker_planck_error._get_scores(
+            relative_coordinates, times, unit_cells
+        )
+
+        batch_size, natoms, spatial_dimension = relative_coordinates.shape
+
+        expected_score_norms = torch.zeros(batch_size)
+        for atom_idx in range(natoms):
+            for space_idx in range(spatial_dimension):
+                expected_score_norms += scores[:, atom_idx, space_idx] ** 2
+
+        computed_score_norms = score_fokker_planck_error._get_scores_square_norm(
+            relative_coordinates, times, unit_cells
+        )
+
+        torch.testing.assert_close(computed_score_norms, expected_score_norms)
+
+    def test_get_gradient_term(
+        self, score_fokker_planck_error, relative_coordinates, times, unit_cells
+    ):
+        x = torch.tensor(relative_coordinates, requires_grad=True)
+
+        epsilon = 1.0e-6
+        batch_size, natoms, spatial_dimension = relative_coordinates.shape
+
+        expected_gradient_term = torch.zeros_like(relative_coordinates)
+        for atom_idx in range(natoms):
+            for space_idx in range(spatial_dimension):
+                dx = torch.zeros_like(relative_coordinates)
+                dx[:, atom_idx, space_idx] = epsilon
+
+                ns_p = score_fokker_planck_error._get_score_divergence(
+                    x + dx, times, unit_cells
+                )
+                s2_p = score_fokker_planck_error._get_scores_square_norm(
+                    x + dx, times, unit_cells
+                )
+                ns_m = score_fokker_planck_error._get_score_divergence(
+                    x - dx, times, unit_cells
+                )
+                s2_m = score_fokker_planck_error._get_scores_square_norm(
+                    x - dx, times, unit_cells
+                )
+
+                expected_gradient_term[:, atom_idx, space_idx] = (
+                    ns_p + s2_p - ns_m - s2_m
+                ) / (2.0 * epsilon)
+
+        computed_gradient_term = score_fokker_planck_error._get_gradient_term(
+            x, times, unit_cells
+        )
+
+        torch.testing.assert_close(expected_gradient_term, computed_gradient_term)
+
+    def test_get_score_fokker_planck_error(
+        self, score_fokker_planck_error, relative_coordinates, times, unit_cells
+    ):
+        errors = score_fokker_planck_error.get_score_fokker_planck_error(
+            relative_coordinates, times, unit_cells
+        )
+        # since we are using an analytical score, which is exact, the FP equation should be exactly satisfied.
+        torch.testing.assert_close(errors, torch.zeros_like(errors))

--- a/tests/samplers/test_exploding_variance.py
+++ b/tests/samplers/test_exploding_variance.py
@@ -1,0 +1,73 @@
+import pytest
+import torch
+
+from crystal_diffusion.samplers.exploding_variance import ExplodingVariance
+from crystal_diffusion.samplers.variance_sampler import NoiseParameters
+
+
+class TestExplodingVariance:
+
+    @pytest.fixture(scope="class", autouse=True)
+    def set_random_seed(self):
+        torch.manual_seed(23423)
+
+    @pytest.fixture()
+    def sigma_min(self):
+        return 0.001
+
+    @pytest.fixture()
+    def sigma_max(self):
+        return 0.5
+
+    @pytest.fixture()
+    def noise_parameters(self, sigma_min, sigma_max):
+        return NoiseParameters(total_time_steps=10,
+                               sigma_min=sigma_min,
+                               sigma_max=sigma_max)
+
+    @pytest.fixture()
+    def times(self):
+        return torch.rand(100)
+
+    @pytest.fixture()
+    def exploding_variance(self, noise_parameters):
+        return ExplodingVariance(noise_parameters)
+
+    @pytest.fixture()
+    def expected_sigmas(self, noise_parameters, times):
+        expected_sigmas = []
+        for t in times:
+            sigma = noise_parameters.sigma_min**(1. - t) * noise_parameters.sigma_max**t
+            expected_sigmas.append(sigma)
+
+        return torch.tensor(expected_sigmas)
+
+    def test_get_sigma(self, exploding_variance, times, expected_sigmas):
+        computed_sigmas = exploding_variance.get_sigma(times)
+        torch.testing.assert_close(computed_sigmas, expected_sigmas)
+
+    def test_get_sigma_time_derivative(self, exploding_variance, times):
+        computed_sigmas_dot = exploding_variance.get_sigma_time_derivative(times)
+
+        t = torch.tensor(times, requires_grad=True)
+        sigma = exploding_variance.get_sigma(t)
+
+        gradients = torch.ones_like(sigma)
+        sigma.backward(gradients)
+
+        expected_sigma_dot = t.grad
+        torch.testing.assert_close(computed_sigmas_dot, expected_sigma_dot)
+
+    def test_get_g_squared(self, exploding_variance, times):
+        computed_g_squared = exploding_variance.get_g_squared(times)
+
+        t = torch.tensor(times, requires_grad=True)
+        sigma = exploding_variance.get_sigma(t)
+
+        sigma_squared = sigma ** 2
+
+        gradients = torch.ones_like(sigma_squared)
+        sigma_squared.backward(gradients)
+        expected_g_squared = t.grad
+
+        torch.testing.assert_close(expected_g_squared, computed_g_squared)


### PR DESCRIPTION
Implementation of a Score Fokker-Planck Error calculator, as defined in the paper
"FP-Diffusion: Improving Score-based Diffusion Models by Enforcing  the Underlying Score Fokker-Planck Equation".

The code makes extensive use of Pytorch autograd; the main entry point is `ScoreFokkerPlanckError. get_score_fokker_planck_error`.