### PR TITLE
radial cutoff for the adjacency matrix in egnn

### DIFF
--- a/crystal_diffusion/models/egnn_utils.py
+++ b/crystal_diffusion/models/egnn_utils.py
@@ -2,6 +2,8 @@ from typing import List
 
 import torch
 
+from crystal_diffusion.models.mace_utils import get_adj_matrix
+
 
 def unsorted_segment_sum(data: torch.Tensor, segment_ids: torch.Tensor, num_segments: int) -> torch.Tensor:
     """Sum all the elements in data by their ids.
@@ -85,3 +87,33 @@ def get_edges_batch(n_nodes: int, batch_size: int) -> torch.Tensor:
             all_edges.append(edges + n_nodes * i)
         edges = torch.cat(all_edges)
     return edges
+
+
+def get_edges_with_radial_cutoff(relative_coordinates: torch.Tensor, unit_cell: torch.Tensor,
+                                 radial_cutoff: float = 4.0, drop_duplicate_edges: bool = True) -> torch.Tensor:
+    """Get edges for a batch with a cutoff based on distance.
+
+    Args:
+        relative_coordinates: batch x n_atom x spatial dimension tensor with relative coordinates
+        unit_cell: batch x spatial dimension x spatial dimension tensor with the unit cell vectors
+        radial_cutoff (optional): cutoff distance in Angstrom. Defaults to 4.0
+        drop_duplicate_edges (optional): if True, return only 1 instance of each edge. If False, return each edge
+            multiple times, depending on the unit cell shift multiplicities. Defaults to True.
+
+    Returns:
+        long tensor of size [number of edges, 2] with edge indices
+    """
+    cartesian_coordinates = relative_coordinates @ unit_cell  # convert back to cartesian coordinates
+    adj_matrix, _, _, _ = get_adj_matrix(cartesian_coordinates, unit_cell, radial_cutoff)
+    # adj_matrix is a n_edges x 2 tensor with duplicates with different shifts.
+    # the uplifting in 2 x spatial_dimension manages the shifts in a natural way. This means we can ignore the shifts
+    # and possibly ignore the multiplicities i.e. no need to sum twice the contribution of a neighbor that we see
+    # in the unitcell and in a shifted unit cell.
+    # TODO check this statement - test with and without multiplicities - just remove the duplicate drop that follows to
+    # test the w/o multiplicities case
+    if drop_duplicate_edges:
+        adj_matrix = torch.unique(adj_matrix, dim=1)  # compare x[0,:] to x[1, :] to find duplicates and drop them
+    # MACE adj calculations returns a (2, n_edges) tensor and EGNN expects a (n_edges, 2) tensor
+    adj_matrix = adj_matrix.transpose(0, 1)
+
+    return adj_matrix


### PR DESCRIPTION
Use the MACE implementation of the adjacency matrix calculation in EGNN. The distance cutoff to determine an edge is based on the original 3D positions, not the uplifted 6D positions.
One of the N fixes to make the Si 2x2x2 diffusion work.