### PR TITLE
More rigid radial cutoff parameters in EGNN.

### DIFF
--- a/crystal_diffusion/models/score_networks/egnn_score_network.py
+++ b/crystal_diffusion/models/score_networks/egnn_score_network.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import AnyStr, Dict
+from typing import AnyStr, Dict, Union
 
 import einops
 import torch
@@ -31,7 +31,7 @@ class EGNNScoreNetworkParameters(ScoreNetworkParameters):
     message_agg: str = "mean"
     n_layers: int = 4
     edges: str = 'fully_connected'
-    radial_cutoff: float = 4.0
+    radial_cutoff: Union[float, None] = None
     drop_duplicate_edges: bool = True
 
 
@@ -60,7 +60,15 @@ class EGNNScoreNetwork(ScoreNetwork):
         self.edges = hyper_params.edges
         assert self.edges in ["fully_connected", "radial_cutoff"], \
             f'Edges type should be fully_connected or radial_cutoff. Got {self.edges}'
+
         self.radial_cutoff = hyper_params.radial_cutoff
+
+        if self.edges == "fully_connected":
+            assert self.radial_cutoff is None, "Specifying a radial cutoff is inconsistent with edges=fully_connected."
+        else:
+            assert type(self.radial_cutoff) is float, \
+                "A floating point value for the radial cutoff is needed for edges=radial_cutoff."
+
         self.drop_duplicate_edges = hyper_params.drop_duplicate_edges
 
         self.egnn = EGNN(

--- a/examples/config_files/diffusion/config_diffusion_egnn.yaml
+++ b/examples/config_files/diffusion/config_diffusion_egnn.yaml
@@ -33,6 +33,7 @@ model:
     normalize: True
     residual: True
     tanh: False
+    edges: fully_connected
   noise:
     total_time_steps: 1000
     sigma_min: 0.0001


### PR DESCRIPTION
I fell in the trap of specifying `radial_cutoff` and `edges` inconsistently. Since the default value of `edges` is `fully_connected`, specifying only `radial_cutoff` does nothing and a fully connected calculation takes place. 

To avoid giving the user the ability to shoot themselves in the foot (as I did), here I implement a consistency check on these two inputs. 

I also corrected a "bug" in the test suite: the EGNN model should *not* be equivariant to the octahedral point group for arbitrary basis vectors; it should only be equivariant for a cubic unit cell. It is weird that the tests passed with a fully connected graph: I suppose that the lattice vectors don't matter in that case... 