### PR TITLE
Atom type sampling powerup

### DIFF
--- a/src/diffusion_for_multi_scale_molecular_dynamics/generators/axl_generator.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/generators/axl_generator.py
@@ -27,6 +27,7 @@ class SamplingParameters:
     record_samples: bool = (
         False  # should the predictor and corrector steps be recorded to a file
     )
+    record_samples_corrector_steps: bool = False
 
 
 class AXLGenerator(ABC):

--- a/src/diffusion_for_multi_scale_molecular_dynamics/generators/langevin_generator.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/generators/langevin_generator.py
@@ -382,10 +382,14 @@ class LangevinGenerator(PredictorCorrectorAXLGenerator):
         composition_im1 = AXL(A=a_im1, X=x_im1, L=unit_cell)  # TODO : Deal with L correctly
 
         if self.record:
-            entry = dict(time_step_index=index_i,
-                         composition_i=composition_i,
-                         composition_im1=composition_im1,
-                         model_predictions_i=model_predictions_i)
+            # Keep the record on the CPU
+            entry = dict(time_step_index=index_i)
+            list_keys = ['composition_i', 'composition_im1', 'model_predictions_i']
+            list_axl = [composition_i, composition_im1, model_predictions_i]
+
+            for key, axl in zip(list_keys, list_axl):
+                record_axl = AXL(A=axl.A.detach().cpu(), X=axl.X.detach().cpu(), L=axl.L.detach().cpu())
+                entry[key] = record_axl
             self.sample_trajectory_recorder.record(key="predictor_step", entry=entry)
 
         return composition_im1
@@ -460,10 +464,15 @@ class LangevinGenerator(PredictorCorrectorAXLGenerator):
         )
 
         if self.record:
-            entry = dict(time_step_index=index_i,
-                         composition_i=composition_i,
-                         corrected_composition_i=corrected_composition_i,
-                         model_predictions_i=model_predictions_i)
+            # Keep the record on the CPU
+            entry = dict(time_step_index=index_i)
+            list_keys = ['composition_i', 'corrected_composition_i', 'model_predictions_i']
+            list_axl = [composition_i, corrected_composition_i, model_predictions_i]
+
+            for key, axl in zip(list_keys, list_axl):
+                record_axl = AXL(A=axl.A.detach().cpu(), X=axl.X.detach().cpu(), L=axl.L.detach().cpu())
+                entry[key] = record_axl
+
             self.sample_trajectory_recorder.record(key="corrector_step", entry=entry)
 
         return corrected_composition_i

--- a/src/diffusion_for_multi_scale_molecular_dynamics/generators/langevin_generator.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/generators/langevin_generator.py
@@ -242,10 +242,10 @@ class LangevinGenerator(PredictorCorrectorAXLGenerator):
             # if we use greedy sampling, we will update the transition probabilities for the MASK token
             # so that we have a non-zero chance of doing a transition from MASK to not-MASK at any time step
             # this will also affect the random gumbel noise u
-            one_step_transition_probs, u = self.adjust_atom_types_probabilities_for_greedy_sampling(
-                one_step_transition_probs,
-                atom_types_i,
-                u
+            one_step_transition_probs, u = (
+                self.adjust_atom_types_probabilities_for_greedy_sampling(
+                    one_step_transition_probs, atom_types_i, u
+                )
             )
 
         # find the updated atom types by sampling from the transition probabilities using the gumbel-softmax trick
@@ -320,6 +320,7 @@ class LangevinGenerator(PredictorCorrectorAXLGenerator):
         )
         do_greedy_sampling = torch.logical_and(do_greedy_sampling, atom_is_masked)
         # replace the probability of getting a mask for those by 0 - so that state cannot be sampled
+
         one_step_transition_probs[:, :, -1] = torch.where(
             do_greedy_sampling, 0, one_step_transition_probs[:, :, -1]
         )

--- a/src/diffusion_for_multi_scale_molecular_dynamics/generators/langevin_generator.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/generators/langevin_generator.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 import torch
 
 from diffusion_for_multi_scale_molecular_dynamics.generators.predictor_corrector_axl_generator import (
@@ -220,18 +222,19 @@ class LangevinGenerator(PredictorCorrectorAXLGenerator):
             small_epsilon=self.small_epsilon,
             probability_at_zeroth_timestep_are_logits=True,
         )  # p(a_{t-1} | a_t) as a [num_samples, num_atoms, num_classes] tensor
-        # sample new atom types from p(a_{t-1} | a_t) using the gumbel trick
+
         if self.atom_type_greedy_sampling:
-            # greedy sampling for sequences that are not all masks
-            all_masked = torch.all(
-                atom_types_i == self.num_classes - 1, dim=-1
-            )  # dim: number_of_samples,
-            # replace u with a constant for the samples that are not all MASK
-            u = torch.where(all_masked.view(-1, 1, 1), u, 0.0)
-            # this is equivalent to sampling the most likely atom type - i.e. greedy sampling
+            # if we use greedy sampling, we will update the transition probabilities for the MASK token
+            # so that we have a non-zero chance of doing a transition from MASK to not-MASK at any time step
+            # this will also affect the random gumbel noise u
+            one_step_transition_probs, u = self.adjust_atom_types_probabilities_for_greedy_sampling(
+                one_step_transition_probs,
+                atom_types_i,
+                u
+            )
 
         # find the updated atom types by sampling from the transition probabilities using the gumbel-softmax trick
-        # we also keep the associated scores in memory so we can compare which transitions are the most likely
+        # we also keep the associated scores in memory, so we can compare which transitions are the most likely
         max_logits_per_atom, updated_atom_types = torch.max(
             torch.log(one_step_transition_probs) + u, dim=-1
         )
@@ -256,6 +259,45 @@ class LangevinGenerator(PredictorCorrectorAXLGenerator):
             )
             # TODO some sanity check at the last step because this approach does not guarantee a full transition...
         return a_im1
+
+    def adjust_atom_types_probabilities_for_greedy_sampling(
+            self,
+            one_step_transition_probs: torch.Tensor,
+            atom_types_i: torch.LongTensor,
+            u: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Update the transition probabilities and the gumbel random variables to allow greedy sampling.
+
+        At time step i, for every atom in a sample, we sample a random number. If it is larger than the probability of
+        that atom being in the MASK class, then we will sample greedily a new atom type (i.e. the most likely). To do
+        that, we simply replace the probability of the MASK class to zero and the gumbel noise u to zero. For non-MASK
+        atoms, we do nothing. For samples with only MASK atoms, we also do nothing.
+
+        Args:
+            one_step_transition_probs: class distributions at time t-1 given distribution at time t. p(a_{t-1} | a_t)
+            atom_types_i: indices of atom types at time i. Dimension: [number_of_samples, number_of_atoms]
+            u: gumbel noise used for sampling. Dimension: [number_of_samples, number_of_atoms, num_classes]
+
+        Returns:
+            one_step_transition_probs: probabilities are updated so a MASK to non-MASK transition can happen
+            u: set to a constant for samples with at least 1 non-MASK atom
+        """
+        # check which samples have at least 1 non-MASK atom
+        all_masked = torch.all(atom_types_i == self.num_classes - 1, dim=-1)  # dim: number_of_samples,
+
+        # we will first erase the probability of staying MASK for some atoms randomly by drawing from a binary
+        # distribution given by one_step_transition_probs[:, :, -1] i.e. the probabilities related to the MASK class.
+        # sample to override the MASK probability as the most likely
+        binary_sample = self._draw_binary_sample(atom_types_i.shape[0])
+        sampled_unmasked = binary_sample > one_step_transition_probs[:, :, -1]
+        # if we override the MASK probability & there's already a non-MASK sample, use a greedy sampling for that atom
+        do_greedy_sampling = torch.logical_and(~all_masked.view(-1, 1), sampled_unmasked)
+        # replace the probability of getting a mask for those by 0 - so that stat cannot be sampled
+        one_step_transition_probs[:, :, -1] = torch.where(do_greedy_sampling, 0, one_step_transition_probs[:, :, -1])
+
+        # replace u with a constant for samples with a non-MASK token present - this ensures a greedy sampling
+        u = torch.where(all_masked.view(-1, 1, 1), u, 0.0)
+        return one_step_transition_probs, u
 
     def predictor_step(
         self,

--- a/src/diffusion_for_multi_scale_molecular_dynamics/generators/langevin_generator.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/generators/langevin_generator.py
@@ -1,4 +1,3 @@
-from typing import Tuple
 import dataclasses
 from typing import Tuple
 

--- a/src/diffusion_for_multi_scale_molecular_dynamics/generators/langevin_generator.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/generators/langevin_generator.py
@@ -55,7 +55,9 @@ class LangevinGenerator(PredictorCorrectorAXLGenerator):
             sampling_parameters.one_atom_type_transition_per_step
         )
         self.atom_type_greedy_sampling = sampling_parameters.atom_type_greedy_sampling
-        self.atom_type_transition_in_corrector = sampling_parameters.atom_type_transition_in_corrector
+        self.atom_type_transition_in_corrector = (
+            sampling_parameters.atom_type_transition_in_corrector
+        )
 
         if sampling_parameters.record_samples:
             self.sample_trajectory_recorder = PredictorCorrectorSampleTrajectory()
@@ -231,10 +233,10 @@ class LangevinGenerator(PredictorCorrectorAXLGenerator):
             # if we use greedy sampling, we will update the transition probabilities for the MASK token
             # so that we have a non-zero chance of doing a transition from MASK to not-MASK at any time step
             # this will also affect the random gumbel noise u
-            one_step_transition_probs, u = self.adjust_atom_types_probabilities_for_greedy_sampling(
-                one_step_transition_probs,
-                atom_types_i,
-                u
+            one_step_transition_probs, u = (
+                self.adjust_atom_types_probabilities_for_greedy_sampling(
+                    one_step_transition_probs, atom_types_i, u
+                )
             )
 
         # find the updated atom types by sampling from the transition probabilities using the gumbel-softmax trick
@@ -265,10 +267,10 @@ class LangevinGenerator(PredictorCorrectorAXLGenerator):
         return a_im1
 
     def adjust_atom_types_probabilities_for_greedy_sampling(
-            self,
-            one_step_transition_probs: torch.Tensor,
-            atom_types_i: torch.LongTensor,
-            u: torch.Tensor,
+        self,
+        one_step_transition_probs: torch.Tensor,
+        atom_types_i: torch.LongTensor,
+        u: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Update the transition probabilities and the gumbel random variables to allow greedy sampling.
 
@@ -287,7 +289,9 @@ class LangevinGenerator(PredictorCorrectorAXLGenerator):
             u: set to a constant for samples with at least 1 non-MASK atom
         """
         # check which samples have at least 1 non-MASK atom
-        all_masked = torch.all(atom_types_i == self.num_classes - 1, dim=-1)  # dim: number_of_samples,
+        all_masked = torch.all(
+            atom_types_i == self.num_classes - 1, dim=-1
+        )  # dim: number_of_samples,
 
         # we will first erase the probability of staying MASK for some atoms randomly by drawing from a binary
         # distribution given by one_step_transition_probs[:, :, -1] i.e. the probabilities related to the MASK class.
@@ -295,9 +299,13 @@ class LangevinGenerator(PredictorCorrectorAXLGenerator):
         binary_sample = self._draw_binary_sample(atom_types_i.shape[0])
         sampled_unmasked = binary_sample > one_step_transition_probs[:, :, -1]
         # if we override the MASK probability & there's already a non-MASK sample, use a greedy sampling for that atom
-        do_greedy_sampling = torch.logical_and(~all_masked.view(-1, 1), sampled_unmasked)
+        do_greedy_sampling = torch.logical_and(
+            ~all_masked.view(-1, 1), sampled_unmasked
+        )
         # replace the probability of getting a mask for those by 0 - so that stat cannot be sampled
-        one_step_transition_probs[:, :, -1] = torch.where(do_greedy_sampling, 0, one_step_transition_probs[:, :, -1])
+        one_step_transition_probs[:, :, -1] = torch.where(
+            do_greedy_sampling, 0, one_step_transition_probs[:, :, -1]
+        )
 
         # replace u with a constant for samples with a non-MASK token present - this ensures a greedy sampling
         u = torch.where(all_masked.view(-1, 1, 1), u, 0.0)
@@ -417,7 +425,9 @@ class LangevinGenerator(PredictorCorrectorAXLGenerator):
         if self.atom_type_transition_in_corrector:
             q_matrices_i = self.noise.q_matrix[index_i].to(composition_i.X)
             q_bar_matrices_i = self.noise.q_bar_matrix[index_i].to(composition_i.X)
-            q_bar_tm1_matrices_i = self.noise.q_bar_tm1_matrix[index_i].to(composition_i.X)
+            q_bar_tm1_matrices_i = self.noise.q_bar_tm1_matrix[index_i].to(
+                composition_i.X
+            )
             # atom types update
             corrected_a_i = self.atom_types_update(
                 model_predictions_i.A,

--- a/src/diffusion_for_multi_scale_molecular_dynamics/generators/langevin_generator.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/generators/langevin_generator.py
@@ -1,5 +1,6 @@
 from typing import Tuple
 import dataclasses
+from typing import Tuple
 
 import torch
 
@@ -237,18 +238,18 @@ class LangevinGenerator(PredictorCorrectorAXLGenerator):
             probability_at_zeroth_timestep_are_logits=True,
         )  # p(a_{t-1} | a_t) as a [num_samples, num_atoms, num_classes] tensor
 
-        # sample new atom types from p(a_{t-1} | a_t) using the gumbel trick
         if self.atom_type_greedy_sampling:
-            # greedy sampling for sequences that are not all masks
-            all_masked = torch.all(
-                atom_types_i == self.num_classes - 1, dim=-1
-            )  # dim: number_of_samples,
-            # replace u with a constant for the samples that are not all MASK
-            u = torch.where(all_masked.view(-1, 1, 1), u, 0.0)
-            # this is equivalent to sampling the most likely atom type - i.e. greedy sampling
+            # if we use greedy sampling, we will update the transition probabilities for the MASK token
+            # so that we have a non-zero chance of doing a transition from MASK to not-MASK at any time step
+            # this will also affect the random gumbel noise u
+            one_step_transition_probs, u = self.adjust_atom_types_probabilities_for_greedy_sampling(
+                one_step_transition_probs,
+                atom_types_i,
+                u
+            )
 
         # find the updated atom types by sampling from the transition probabilities using the gumbel-softmax trick
-        # we also keep the associated scores in memory so we can compare which transitions are the most likely
+        # we also keep the associated scores in memory, so we can compare which transitions are the most likely
         max_logits_per_atom, updated_atom_types = torch.max(
             torch.log(one_step_transition_probs) + u, dim=-1
         )

--- a/src/diffusion_for_multi_scale_molecular_dynamics/generators/langevin_generator.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/generators/langevin_generator.py
@@ -94,6 +94,10 @@ class LangevinGenerator(PredictorCorrectorAXLGenerator):
             )
         )
 
+    def _draw_binary_sample(self, number_of_samples):
+        # this is used to determine if a MASK sample should be demasked or not in greedy sampling
+        return torch.rand(number_of_samples, self.number_of_atoms)
+
     def _get_model_predictions(
         self,
         composition: AXL,

--- a/src/diffusion_for_multi_scale_molecular_dynamics/generators/langevin_generator.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/generators/langevin_generator.py
@@ -68,10 +68,12 @@ class LangevinGenerator(PredictorCorrectorAXLGenerator):
         if self.record:
             self.sample_trajectory_recorder = SampleTrajectory()
             self.sample_trajectory_recorder.record(key="noise", entry=self.noise)
-            self.sample_trajectory_recorder.record(key="noise_parameters",
-                                                   entry=dataclasses.asdict(noise_parameters))
-            self.sample_trajectory_recorder.record(key="sampling_parameters",
-                                                   entry=dataclasses.asdict(sampling_parameters))
+            self.sample_trajectory_recorder.record(
+                key="noise_parameters", entry=dataclasses.asdict(noise_parameters)
+            )
+            self.sample_trajectory_recorder.record(
+                key="sampling_parameters", entry=dataclasses.asdict(sampling_parameters)
+            )
 
     def initialize(
         self, number_of_samples: int, device: torch.device = torch.device("cpu")
@@ -380,16 +382,22 @@ class LangevinGenerator(PredictorCorrectorAXLGenerator):
             composition_i.X, model_predictions_i.X, sigma_i, g2_i, g_i
         )
 
-        composition_im1 = AXL(A=a_im1, X=x_im1, L=unit_cell)  # TODO : Deal with L correctly
+        composition_im1 = AXL(
+            A=a_im1, X=x_im1, L=unit_cell
+        )  # TODO : Deal with L correctly
 
         if self.record:
             # Keep the record on the CPU
             entry = dict(time_step_index=index_i)
-            list_keys = ['composition_i', 'composition_im1', 'model_predictions_i']
+            list_keys = ["composition_i", "composition_im1", "model_predictions_i"]
             list_axl = [composition_i, composition_im1, model_predictions_i]
 
             for key, axl in zip(list_keys, list_axl):
-                record_axl = AXL(A=axl.A.detach().cpu(), X=axl.X.detach().cpu(), L=axl.L.detach().cpu())
+                record_axl = AXL(
+                    A=axl.A.detach().cpu(),
+                    X=axl.X.detach().cpu(),
+                    L=axl.L.detach().cpu(),
+                )
                 entry[key] = record_axl
             self.sample_trajectory_recorder.record(key="predictor_step", entry=entry)
 
@@ -467,11 +475,19 @@ class LangevinGenerator(PredictorCorrectorAXLGenerator):
         if self.record and self.record_corrector:
             # Keep the record on the CPU
             entry = dict(time_step_index=index_i)
-            list_keys = ['composition_i', 'corrected_composition_i', 'model_predictions_i']
+            list_keys = [
+                "composition_i",
+                "corrected_composition_i",
+                "model_predictions_i",
+            ]
             list_axl = [composition_i, corrected_composition_i, model_predictions_i]
 
             for key, axl in zip(list_keys, list_axl):
-                record_axl = AXL(A=axl.A.detach().cpu(), X=axl.X.detach().cpu(), L=axl.L.detach().cpu())
+                record_axl = AXL(
+                    A=axl.A.detach().cpu(),
+                    X=axl.X.detach().cpu(),
+                    L=axl.L.detach().cpu(),
+                )
                 entry[key] = record_axl
 
             self.sample_trajectory_recorder.record(key="corrector_step", entry=entry)

--- a/src/diffusion_for_multi_scale_molecular_dynamics/generators/langevin_generator.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/generators/langevin_generator.py
@@ -242,7 +242,7 @@ class LangevinGenerator(PredictorCorrectorAXLGenerator):
         # find the updated atom types by sampling from the transition probabilities using the gumbel-softmax trick
         # we also keep the associated scores in memory, so we can compare which transitions are the most likely
         max_logits_per_atom, updated_atom_types = torch.max(
-            torch.log(one_step_transition_probs) + u, dim=-1
+            torch.log(one_step_transition_probs + self.small_epsilon) + u, dim=-1
         )
 
         if not self.one_atom_type_transition_per_step:
@@ -293,15 +293,23 @@ class LangevinGenerator(PredictorCorrectorAXLGenerator):
             atom_types_i == self.num_classes - 1, dim=-1
         )  # dim: number_of_samples,
 
+        # we can only do greedy sampling for atoms that are masked
+        atom_is_masked = atom_types_i == self.num_classes - 1
+
         # we will first erase the probability of staying MASK for some atoms randomly by drawing from a binary
         # distribution given by one_step_transition_probs[:, :, -1] i.e. the probabilities related to the MASK class.
         # sample to override the MASK probability as the most likely
-        binary_sample = self._draw_binary_sample(atom_types_i.shape[0])
-        sampled_unmasked = binary_sample > one_step_transition_probs[:, :, -1]
-        # if we override the MASK probability & there's already a non-MASK sample, use a greedy sampling for that atom
-        do_greedy_sampling = torch.logical_and(
-            ~all_masked.view(-1, 1), sampled_unmasked
+        binary_sample = self._draw_binary_sample(atom_types_i.shape[0]).to(
+            device=atom_types_i.device
         )
+        unmask_this_sample = binary_sample > one_step_transition_probs[:, :, -1]
+        # if we override the MASK probability & there's already a non-MASK sample & that atom is masked,
+        # use a greedy sampling for that atom
+        do_greedy_sampling = torch.logical_and(
+            ~all_masked.view(-1, 1),
+            unmask_this_sample,
+        )
+        do_greedy_sampling = torch.logical_and(do_greedy_sampling, atom_is_masked)
         # replace the probability of getting a mask for those by 0 - so that stat cannot be sampled
         one_step_transition_probs[:, :, -1] = torch.where(
             do_greedy_sampling, 0, one_step_transition_probs[:, :, -1]
@@ -409,6 +417,7 @@ class LangevinGenerator(PredictorCorrectorAXLGenerator):
                 self.noise_parameters.sigma_min
             )  # no need to change device, this is a float
             t_i = 0.0  # same for device - this is a float
+            idx = index_i
         else:
             idx = index_i - 1  # python starts indices at zero
             sigma_i = self.noise.sigma[idx].to(composition_i.X)
@@ -423,11 +432,9 @@ class LangevinGenerator(PredictorCorrectorAXLGenerator):
         )
 
         if self.atom_type_transition_in_corrector:
-            q_matrices_i = self.noise.q_matrix[index_i].to(composition_i.X)
-            q_bar_matrices_i = self.noise.q_bar_matrix[index_i].to(composition_i.X)
-            q_bar_tm1_matrices_i = self.noise.q_bar_tm1_matrix[index_i].to(
-                composition_i.X
-            )
+            q_matrices_i = self.noise.q_matrix[idx].to(composition_i.X)
+            q_bar_matrices_i = self.noise.q_bar_matrix[idx].to(composition_i.X)
+            q_bar_tm1_matrices_i = self.noise.q_bar_tm1_matrix[idx].to(composition_i.X)
             # atom types update
             corrected_a_i = self.atom_types_update(
                 model_predictions_i.A,

--- a/src/diffusion_for_multi_scale_molecular_dynamics/generators/langevin_generator.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/generators/langevin_generator.py
@@ -62,6 +62,7 @@ class LangevinGenerator(PredictorCorrectorAXLGenerator):
         )
 
         self.record = sampling_parameters.record_samples
+        self.record_corrector = sampling_parameters.record_samples_corrector_steps
 
         if self.record:
             self.sample_trajectory_recorder = SampleTrajectory()
@@ -463,7 +464,7 @@ class LangevinGenerator(PredictorCorrectorAXLGenerator):
             L=unit_cell,  # TODO replace with AXL-L
         )
 
-        if self.record:
+        if self.record and self.record_corrector:
             # Keep the record on the CPU
             entry = dict(time_step_index=index_i)
             list_keys = ['composition_i', 'corrected_composition_i', 'model_predictions_i']

--- a/src/diffusion_for_multi_scale_molecular_dynamics/generators/langevin_generator.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/generators/langevin_generator.py
@@ -53,6 +53,7 @@ class LangevinGenerator(PredictorCorrectorAXLGenerator):
             sampling_parameters.one_atom_type_transition_per_step
         )
         self.atom_type_greedy_sampling = sampling_parameters.atom_type_greedy_sampling
+        self.atom_type_transition_in_corrector = sampling_parameters.atom_type_transition_in_corrector
 
         if sampling_parameters.record_samples:
             self.sample_trajectory_recorder = PredictorCorrectorSampleTrajectory()
@@ -367,8 +368,23 @@ class LangevinGenerator(PredictorCorrectorAXLGenerator):
             composition_i.X, model_predictions_i.X, sigma_i, eps_i, sqrt_2eps_i
         )
 
+        if self.atom_type_transition_in_corrector:
+            q_matrices_i = self.noise.q_matrix[index_i].to(composition_i.X)
+            q_bar_matrices_i = self.noise.q_bar_matrix[index_i].to(composition_i.X)
+            q_bar_tm1_matrices_i = self.noise.q_bar_tm1_matrix[index_i].to(composition_i.X)
+            # atom types update
+            corrected_a_i = self.atom_types_update(
+                model_predictions_i.A,
+                composition_i.A,
+                q_matrices_i,
+                q_bar_matrices_i,
+                q_bar_tm1_matrices_i,
+            )
+        else:
+            corrected_a_i = composition_i.A
+
         corrected_composition_i = AXL(
-            A=composition_i.A,
+            A=corrected_a_i,
             X=corrected_x_i,
             L=composition_i.L,
         )

--- a/src/diffusion_for_multi_scale_molecular_dynamics/generators/langevin_generator.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/generators/langevin_generator.py
@@ -1,4 +1,5 @@
 from typing import Tuple
+import dataclasses
 
 import torch
 
@@ -16,8 +17,8 @@ from diffusion_for_multi_scale_molecular_dynamics.utils.basis_transformations im
     map_relative_coordinates_to_unit_cell
 from diffusion_for_multi_scale_molecular_dynamics.utils.d3pm_utils import (
     class_index_to_onehot, get_probability_at_previous_time_step)
-from diffusion_for_multi_scale_molecular_dynamics.utils.sample_trajectory import (
-    NoOpPredictorCorrectorSampleTrajectory, PredictorCorrectorSampleTrajectory)
+from diffusion_for_multi_scale_molecular_dynamics.utils.sample_trajectory import \
+    SampleTrajectory
 
 
 class LangevinGenerator(PredictorCorrectorAXLGenerator):
@@ -60,10 +61,15 @@ class LangevinGenerator(PredictorCorrectorAXLGenerator):
             sampling_parameters.atom_type_transition_in_corrector
         )
 
-        if sampling_parameters.record_samples:
-            self.sample_trajectory_recorder = PredictorCorrectorSampleTrajectory()
-        else:
-            self.sample_trajectory_recorder = NoOpPredictorCorrectorSampleTrajectory()
+        self.record = sampling_parameters.record_samples
+
+        if self.record:
+            self.sample_trajectory_recorder = SampleTrajectory()
+            self.sample_trajectory_recorder.record(key="noise", entry=self.noise)
+            self.sample_trajectory_recorder.record(key="noise_parameters",
+                                                   entry=dataclasses.asdict(noise_parameters))
+            self.sample_trajectory_recorder.record(key="sampling_parameters",
+                                                   entry=dataclasses.asdict(sampling_parameters))
 
     def initialize(
         self, number_of_samples: int, device: torch.device = torch.device("cpu")
@@ -373,19 +379,14 @@ class LangevinGenerator(PredictorCorrectorAXLGenerator):
             composition_i.X, model_predictions_i.X, sigma_i, g2_i, g_i
         )
 
-        composition_im1 = AXL(A=a_im1, X=x_im1, L=composition_i.L)  # TODO placeholder
+        composition_im1 = AXL(A=a_im1, X=x_im1, L=unit_cell)  # TODO : Deal with L correctly
 
-        self.sample_trajectory_recorder.record_unit_cell(
-            unit_cell=unit_cell
-        )  # TODO replace with AXL-L
-        self.sample_trajectory_recorder.record_predictor_step(
-            i_index=index_i,
-            time=t_i,
-            sigma=sigma_i,
-            composition_i=composition_i,
-            composition_im1=composition_im1,
-            model_predictions_i=model_predictions_i,
-        )
+        if self.record:
+            entry = dict(time_step_index=index_i,
+                         composition_i=composition_i,
+                         composition_im1=composition_im1,
+                         model_predictions_i=model_predictions_i)
+            self.sample_trajectory_recorder.record(key="predictor_step", entry=entry)
 
         return composition_im1
 
@@ -455,16 +456,14 @@ class LangevinGenerator(PredictorCorrectorAXLGenerator):
         corrected_composition_i = AXL(
             A=corrected_a_i,
             X=corrected_x_i,
-            L=composition_i.L,
+            L=unit_cell,  # TODO replace with AXL-L
         )
 
-        self.sample_trajectory_recorder.record_corrector_step(
-            i_index=index_i,
-            time=t_i,
-            sigma=sigma_i,
-            composition_i=composition_i,
-            corrected_composition_i=corrected_composition_i,
-            model_predictions_i=model_predictions_i,
-        )
+        if self.record:
+            entry = dict(time_step_index=index_i,
+                         composition_i=composition_i,
+                         corrected_composition_i=corrected_composition_i,
+                         model_predictions_i=model_predictions_i)
+            self.sample_trajectory_recorder.record(key="corrector_step", entry=entry)
 
         return corrected_composition_i

--- a/src/diffusion_for_multi_scale_molecular_dynamics/generators/predictor_corrector_axl_generator.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/generators/predictor_corrector_axl_generator.py
@@ -21,6 +21,7 @@ class PredictorCorrectorSamplingParameters(SamplingParameters):
     small_epsilon: float = 1e-8
     one_atom_type_transition_per_step: bool = True
     atom_type_greedy_sampling: bool = True
+    atom_type_transition_in_corrector: bool = False
 
 
 class PredictorCorrectorAXLGenerator(AXLGenerator):

--- a/src/diffusion_for_multi_scale_molecular_dynamics/generators/predictor_corrector_axl_generator.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/generators/predictor_corrector_axl_generator.py
@@ -19,10 +19,12 @@ class PredictorCorrectorSamplingParameters(SamplingParameters):
     algorithm: str = "predictor_corrector"
     number_of_corrector_steps: int = 1
     small_epsilon: float = 1e-8
+    one_atom_type_transition_per_step: bool = True
+    atom_type_greedy_sampling: bool = True
 
 
 class PredictorCorrectorAXLGenerator(AXLGenerator):
-    """This defines the interface for predictor-corrector AXL (atom types, reduced coordinates and lattice) generators."""
+    """Defines the interface for predictor-corrector AXL (atom types, relative coordinates and lattice) generators."""
 
     def __init__(
         self,

--- a/src/diffusion_for_multi_scale_molecular_dynamics/utils/sample_trajectory.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/utils/sample_trajectory.py
@@ -1,7 +1,12 @@
 from collections import defaultdict
+from pathlib import Path
 from typing import Any, Dict, NamedTuple, Union
 
+import einops
+import numpy as np
 import torch
+
+from diffusion_for_multi_scale_molecular_dynamics.namespace import AXL
 
 
 class SampleTrajectory:
@@ -37,3 +42,52 @@ class SampleTrajectory:
         """Write data to pickle file."""
         with open(path_to_pickle, "wb") as fd:
             torch.save(self._internal_data, fd)
+
+
+def get_predictor_trajectory(pickle_path: Path) -> AXL:
+    """Get predictor trajectory.
+
+    Args:
+        pickle_path: location of the output of a sample_trajectory object for a Langevin generator.
+
+    Returns:
+        trajectory_axl: trajectory composition object, where each field has dimension [nsamples, time, ...]
+    """
+    data = torch.load(pickle_path, map_location=torch.device("cpu"))
+
+    predictor_data = data["predictor_step"]
+
+    # The recording might have taken place over multiple batches. Combine corresponding compositions.
+    multiple_batch_compositions = defaultdict(list)
+    for entry in predictor_data:
+        time_index = entry["time_step_index"]
+        axl_composition = entry["composition_im1"]
+        multiple_batch_compositions[time_index].append(axl_composition)
+
+    list_time_indices = np.sort(np.array(list(multiple_batch_compositions.keys())))[
+        ::-1
+    ]
+
+    list_compositions = []
+    for time_index in list_time_indices:
+        batch_compositions = multiple_batch_compositions[time_index]
+        composition = AXL(
+            A=torch.vstack([c.A for c in batch_compositions]),
+            X=torch.vstack([c.X for c in batch_compositions]),
+            L=torch.vstack([c.L for c in batch_compositions]),
+        )
+        list_compositions.append(composition)
+
+    atoms_types = einops.rearrange(
+        [c.A for c in list_compositions], "time batch natoms -> batch time natoms"
+    )
+    relative_coordinates = einops.rearrange(
+        [c.X for c in list_compositions],
+        "time batch natoms space -> batch time natoms space",
+    )
+    lattice = einops.rearrange(
+        [c.L for c in list_compositions], "time batch d1 d2-> batch time d1 d2"
+    )
+    trajectory_axl = AXL(A=atoms_types, X=relative_coordinates, L=lattice)
+
+    return trajectory_axl

--- a/src/diffusion_for_multi_scale_molecular_dynamics/utils/sample_trajectory.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/utils/sample_trajectory.py
@@ -1,257 +1,39 @@
 from collections import defaultdict
-from typing import Any, AnyStr, Dict
+from typing import Any, Dict, NamedTuple, Union
 
-import einops
 import torch
-
-from diffusion_for_multi_scale_molecular_dynamics.namespace import (
-    AXL, AXL_NAME_DICT)
 
 
 class SampleTrajectory:
     """Sample Trajectory.
 
-    This class aims to record all details of the diffusion sampling process. The goal is to produce
+    This class aims to record the diffusion sampling process. The goal is to produce
     an artifact that can then be analyzed off-line.
     """
 
     def __init__(self):
         """Init method."""
-        self.data = defaultdict(list)
+        self._internal_data = defaultdict(list)
 
     def reset(self):
         """Reset data structure."""
-        self.data = defaultdict(list)
+        self._internal_data = defaultdict(list)
 
-    def record_unit_cell(self, unit_cell: torch.Tensor):
-        """Record unit cell."""
-        self.data["unit_cell"] = unit_cell.detach().cpu()
+    def record(self, key: str, entry: Union[Dict[str, Any], NamedTuple]):
+        """Record.
 
-    def standardize_data(self, data: Dict[AnyStr, Any]) -> Dict[AnyStr, Any]:
-        """Method to transform the recorded data to a standard form."""
-        raise NotImplementedError("Must be implemented in child class.")
+        Record data from a trajectory.
+
+        Args:
+            key: name of  internal list to which the entry will be added.
+            entry: dictionary-like data to be recorded.
+
+        Returns:
+            None.
+        """
+        self._internal_data[key].append(entry)
 
     def write_to_pickle(self, path_to_pickle: str):
-        """Write standardized data to pickle file."""
-        standard_data = self.standardize_data(self.data)
+        """Write data to pickle file."""
         with open(path_to_pickle, "wb") as fd:
-            torch.save(standard_data, fd)
-
-
-class ODESampleTrajectory(SampleTrajectory):
-    """ODE Sample Trajectory.
-
-    This class aims to record all details of the ODE diffusion sampling process. The goal is to produce
-    an artifact that can then be analyzed off-line.
-    """
-
-    def record_ode_solution(
-        self,
-        times: torch.Tensor,
-        sigmas: torch.Tensor,
-        relative_coordinates: torch.Tensor,
-        normalized_scores: torch.Tensor,
-        stats: Dict,
-        status: torch.Tensor,
-    ):
-        """Record ODE solution information."""
-        self.data["time"].append(times)
-        self.data["sigma"].append(sigmas)
-        self.data["relative_coordinates"].append(relative_coordinates)
-        self.data["normalized_scores"].append(normalized_scores)
-        self.data["stats"].append(stats)
-        self.data["status"].append(status)
-
-    def standardize_data(self, data: Dict[AnyStr, Any]) -> Dict[AnyStr, Any]:
-        """Method to transform the recorded data to a standard form."""
-        extra_fields = ["stats", "status"]
-        standardized_data = dict(
-            unit_cell=data["unit_cell"],
-            time=data["time"][0],
-            sigma=data["sigma"][0],
-            relative_coordinates=data["relative_coordinates"][0],
-            normalized_scores=data["normalized_scores"][0],
-            extra={key: data[key][0] for key in extra_fields},
-        )
-        return standardized_data
-
-
-class SDESampleTrajectory(SampleTrajectory):
-    """SDE Sample Trajectory.
-
-    This class aims to record all details of the SDE diffusion sampling process. The goal is to produce
-    an artifact that can then be analyzed off-line.
-    """
-
-    def record_sde_solution(
-        self,
-        times: torch.Tensor,
-        sigmas: torch.Tensor,
-        relative_coordinates: torch.Tensor,
-        normalized_scores: torch.Tensor,
-    ):
-        """Record ODE solution information."""
-        self.data["time"].append(times)
-        self.data["sigma"].append(sigmas)
-        self.data["relative_coordinates"].append(relative_coordinates)
-        self.data["normalized_scores"].append(normalized_scores)
-
-    def standardize_data(self, data: Dict[AnyStr, Any]) -> Dict[AnyStr, Any]:
-        """Method to transform the recorded data to a standard form."""
-        standardized_data = dict(
-            unit_cell=data["unit_cell"],
-            time=data["time"][0],
-            sigma=data["sigma"][0],
-            relative_coordinates=data["relative_coordinates"][0],
-            normalized_scores=data["normalized_scores"][0],
-        )
-        return standardized_data
-
-
-class NoOpODESampleTrajectory(ODESampleTrajectory):
-    """A sample trajectory object that performs no operation."""
-
-    def record_unit_cell(self, unit_cell: torch.Tensor):
-        """No Op."""
-        return
-
-    def record_ode_solution(
-        self,
-        times: torch.Tensor,
-        sigmas: torch.Tensor,
-        relative_coordinates: torch.Tensor,
-        normalized_scores: torch.Tensor,
-        stats: Dict,
-        status: torch.Tensor,
-    ):
-        """No Op."""
-        return
-
-    def write_to_pickle(self, path_to_pickle: str):
-        """No Op."""
-        return
-
-
-class PredictorCorrectorSampleTrajectory(SampleTrajectory):
-    """Predictor Corrector Sample Trajectory.
-
-    This class aims to record all details of the predictor-corrector diffusion sampling process. The goal is to produce
-    an artifact that can then be analyzed off-line.
-    """
-
-    def record_predictor_step(
-        self,
-        i_index: int,
-        time: float,
-        sigma: float,
-        composition_i: AXL,
-        composition_im1: AXL,
-        model_predictions_i: AXL,
-    ):
-        """Record predictor step."""
-        self.data["predictor_i_index"].append(i_index)
-        self.data["predictor_time"].append(time)
-        self.data["predictor_sigma"].append(sigma)
-        for axl_field, axl_name in AXL_NAME_DICT.items():
-            self.data[f"predictor_{axl_name}_i"].append(
-                getattr(composition_i, axl_field).detach().cpu()
-            )
-            self.data[f"predictor_{axl_name}_im1"].append(
-                getattr(composition_im1, axl_field).detach().cpu()
-            )
-            self.data[f"predictor_{axl_name}_model_predictions"].append(
-                getattr(model_predictions_i, axl_field).detach().cpu()
-            )
-
-    def record_corrector_step(
-        self,
-        i_index: int,
-        time: float,
-        sigma: float,
-        composition_i: AXL,
-        corrected_composition_i: AXL,
-        model_predictions_i: AXL,
-    ):
-        """Record corrector step."""
-        self.data["corrector_i_index"].append(i_index)
-        self.data["corrector_time"].append(time)
-        self.data["corrector_sigma"].append(sigma)
-        for axl_field, axl_name in AXL_NAME_DICT.items():
-            self.data[f"corrector_{axl_name}_i"].append(
-                getattr(composition_i, axl_field).detach().cpu()
-            )
-            self.data[f"corrector_{axl_name}_corrected_i"].append(
-                getattr(corrected_composition_i, axl_field).detach().cpu()
-            )
-            self.data[f"corrector_{axl_name}_model_predictions"].append(
-                getattr(model_predictions_i, axl_field).detach().cpu()
-            )
-
-    def standardize_data(self, data: Dict[AnyStr, Any]) -> Dict[AnyStr, Any]:
-        """Method to transform the recorded data to a standard form."""
-        predictor_relative_coordinates = einops.rearrange(
-            torch.stack(data[f"predictor_{AXL_NAME_DICT['X']}_i"]), "t b n d -> b t n d"
-        )
-        predictor_normalized_scores = einops.rearrange(
-            torch.stack(data[f"predictor_{AXL_NAME_DICT['X']}_model_predictions"]),
-            "t b n d -> b t n d",
-        )
-
-        extra_fields = [
-            "predictor_i_index",
-            "corrector_i_index",
-            "corrector_time",
-            "corrector_sigma",
-            "corrector_scores",
-        ]
-        extra_fields += [f"predictor_{v}_i" for v in AXL_NAME_DICT.values()]
-        extra_fields += [f"predictor_{v}_im1" for v in AXL_NAME_DICT.values()]
-        extra_fields += [f"corrector_{v}_i" for v in AXL_NAME_DICT.values()]
-        extra_fields += [f"corrector_{v}_corrected_i" for v in AXL_NAME_DICT.values()]
-        extra_fields += [f"corrector_{v}_model_outputs" for v in AXL_NAME_DICT.values()]
-
-        standardized_data = dict(
-            unit_cell=data["unit_cell"],
-            time=torch.tensor(data["predictor_time"]),
-            sigma=torch.tensor(data["predictor_sigma"]),
-            relative_coordinates=predictor_relative_coordinates,
-            normalized_scores=predictor_normalized_scores,
-            extra={key: data[key] for key in extra_fields},
-        )
-        return standardized_data
-
-
-class NoOpPredictorCorrectorSampleTrajectory(PredictorCorrectorSampleTrajectory):
-    """A sample trajectory object that performs no operation."""
-
-    def record_unit_cell(self, unit_cell: torch.Tensor):
-        """No Op."""
-        return
-
-    def record_predictor_step(
-        self,
-        i_index: int,
-        time: float,
-        sigma: float,
-        composition_i: AXL,
-        composition_im1: AXL,
-        model_predictions_i: AXL,
-    ):
-        """No Op."""
-        return
-
-    def record_corrector_step(
-        self,
-        i_index: int,
-        time: float,
-        sigma: float,
-        composition_i: AXL,
-        corrected_composition_i: AXL,
-        model_predictions_i: AXL,
-    ):
-        """No Op."""
-        return
-
-    def write_to_pickle(self, path_to_pickle: str):
-        """No Op."""
-        return
+            torch.save(self._internal_data, fd)

--- a/tests/generators/test_langevin_generator.py
+++ b/tests/generators/test_langevin_generator.py
@@ -225,7 +225,7 @@ class TestLangevinGenerator(BaseTestGenerator):
             sigma_i = list_sigma[index_i]
             t_i = list_time[index_i]
 
-            p_ao_given_at_i = pc_generator._get_model_predictions(
+            p_a0_given_at_i = pc_generator._get_model_predictions(
                 axl_i, t_i, sigma_i, unit_cell_sample, forces
             ).A
 
@@ -235,7 +235,7 @@ class TestLangevinGenerator(BaseTestGenerator):
             q_bar_tm1_matrices = list_q_bar_tm1_matrices[index_i]
 
             p_atm1_given_at = get_probability_at_previous_time_step(
-                probability_at_zeroth_timestep=p_ao_given_at_i,
+                probability_at_zeroth_timestep=p_a0_given_at_i,
                 one_hot_probability_at_current_timestep=onehot_at,
                 q_matrices=q_matrices,
                 q_bar_matrices=q_bar_matrices,

--- a/tests/models/test_axl_diffusion_lightning_model.py
+++ b/tests/models/test_axl_diffusion_lightning_model.py
@@ -121,7 +121,7 @@ class TestPositionDiffusionLightningModel:
 
     @pytest.fixture
     def unique_elements(self, num_atom_types):
-        return [generate_random_string(size=3) for _ in range(num_atom_types)]
+        return [generate_random_string(size=8) for _ in range(num_atom_types)]
 
     @pytest.fixture()
     def unit_cell_size(self):

--- a/tests/sampling/test_diffusion_sampling.py
+++ b/tests/sampling/test_diffusion_sampling.py
@@ -25,7 +25,7 @@ class DummyGenerator(AXLGenerator):
     ) -> torch.Tensor:
         self._counter += number_of_samples
         rel_coordinates = self._relative_coordinates[
-            self._counter - number_of_samples : self._counter
+            self._counter - number_of_samples:self._counter
         ]
         return AXL(
             A=torch.zeros_like(rel_coordinates[..., 0]).long(),

--- a/tests/utils/test_sample_trajectory.py
+++ b/tests/utils/test_sample_trajectory.py
@@ -1,13 +1,11 @@
 from copy import deepcopy
 
-import einops
 import pytest
 import torch
 
-from diffusion_for_multi_scale_molecular_dynamics.namespace import (
-    AXL, AXL_NAME_DICT)
+from diffusion_for_multi_scale_molecular_dynamics.namespace import AXL
 from diffusion_for_multi_scale_molecular_dynamics.utils.sample_trajectory import \
-    PredictorCorrectorSampleTrajectory
+    SampleTrajectory
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -57,18 +55,8 @@ def basis_vectors(batch_size):
 
 
 @pytest.fixture(scope="module")
-def list_i_indices(number_of_predictor_steps):
+def list_time_indices(number_of_predictor_steps):
     return torch.arange(number_of_predictor_steps - 1, -1, -1)
-
-
-@pytest.fixture(scope="module")
-def list_sigmas(number_of_predictor_steps):
-    return torch.rand(number_of_predictor_steps)
-
-
-@pytest.fixture(scope="module")
-def list_times(number_of_predictor_steps):
-    return torch.rand(number_of_predictor_steps)
 
 
 @pytest.fixture(scope="module")
@@ -242,178 +230,104 @@ def list_corrected_axl_i(list_corrected_x_i, list_corrected_atom_types_i):
 
 @pytest.fixture(scope="module")
 def sample_trajectory(
-    number_of_corrector_steps,
-    list_i_indices,
-    list_times,
-    list_sigmas,
-    basis_vectors,
-    list_axl_i,
-    list_axl_im1,
-    predictor_model_outputs,
-    list_axl_i_corr,
-    list_corrected_axl_i,
-    corrector_model_outputs,
+        number_of_corrector_steps,
+        list_time_indices,
+        basis_vectors,
+        list_axl_i,
+        list_axl_im1,
+        predictor_model_outputs,
+        list_axl_i_corr,
+        list_corrected_axl_i,
+        corrector_model_outputs,
 ):
-    sample_trajectory = PredictorCorrectorSampleTrajectory()
-    sample_trajectory.record_unit_cell(basis_vectors)
-
+    sample_trajectory_recorder = SampleTrajectory()
     total_corrector_index = 0
 
-    for i_index, time, sigma, axl_i, axl_im1, model_predictions_i in zip(
-        list_i_indices,
-        list_times,
-        list_sigmas,
+    for time_step_index, axl_i, axl_im1, model_predictions_i in zip(
+        list_time_indices,
         list_axl_i,
         list_axl_im1,
         predictor_model_outputs,
     ):
-        sample_trajectory.record_predictor_step(
-            i_index=i_index,
-            time=time,
-            sigma=sigma,
-            composition_i=axl_i,
-            composition_im1=axl_im1,
-            model_predictions_i=model_predictions_i,
-        )
+        entry = dict(time_step_index=time_step_index,
+                     composition_i=axl_i,
+                     composition_im1=axl_im1,
+                     model_predictions_i=model_predictions_i)
+        sample_trajectory_recorder.record(key="predictor_step", entry=entry)
 
         for _ in range(number_of_corrector_steps):
             axl_i = list_axl_i_corr[total_corrector_index]
             corrected_axl_i = list_corrected_axl_i[total_corrector_index]
             model_predictions_i = corrector_model_outputs[total_corrector_index]
-            sample_trajectory.record_corrector_step(
-                i_index=i_index,
-                time=time,
-                sigma=sigma,
-                composition_i=axl_i,
-                corrected_composition_i=corrected_axl_i,
-                model_predictions_i=model_predictions_i,
-            )
+            entry = dict(time_step_index=time_step_index,
+                         composition_i=axl_i,
+                         corrected_composition_i=corrected_axl_i,
+                         model_predictions_i=model_predictions_i)
+            sample_trajectory_recorder.record(key="corrector_step", entry=entry)
+
             total_corrector_index += 1
 
-    return sample_trajectory
+    return sample_trajectory_recorder
 
 
-def test_sample_trajectory_unit_cell(sample_trajectory, basis_vectors):
-    torch.testing.assert_close(sample_trajectory.data["unit_cell"], basis_vectors)
+@pytest.fixture(scope="module")
+def pickle_data(sample_trajectory, tmp_path_factory):
+    path_to_pickle = tmp_path_factory.mktemp("sample_trajectory") / "test.pkl"
+    sample_trajectory.write_to_pickle(path_to_pickle)
+    data = torch.load(path_to_pickle)
+    return data
 
 
-def test_record_predictor(
-    sample_trajectory,
-    list_times,
-    list_sigmas,
-    list_axl_i,
-    list_axl_im1,
-    predictor_model_outputs,
-):
-    torch.testing.assert_close(
-        torch.tensor(sample_trajectory.data["predictor_time"]), list_times
-    )
-    torch.testing.assert_close(
-        torch.tensor(sample_trajectory.data["predictor_sigma"]), list_sigmas
-    )
-    for axl_field, axl_name in AXL_NAME_DICT.items():
-        predictor_i = torch.stack(
-            sample_trajectory.data[f"predictor_{axl_name}_i"], dim=0
-        )
-        target_predictor_i = torch.stack(
-            [getattr(axl, axl_field) for axl in list_axl_i], dim=0
-        )
-        torch.testing.assert_close(predictor_i, target_predictor_i)
-        predictor_im1 = torch.stack(
-            sample_trajectory.data[f"predictor_{axl_name}_im1"], dim=0
-        )
-        target_predictor_im1 = torch.stack(
-            [getattr(axl, axl_field) for axl in list_axl_im1], dim=0
-        )
-        torch.testing.assert_close(predictor_im1, target_predictor_im1)
+def test_predictor_step(number_of_predictor_steps,
+                        pickle_data,
+                        list_time_indices,
+                        list_axl_i,
+                        list_axl_im1,
+                        predictor_model_outputs):
+    assert "predictor_step" in pickle_data
+    predictor_step_data = pickle_data["predictor_step"]
 
-        predictor_mo_i = torch.stack(
-            sample_trajectory.data[f"predictor_{axl_name}_model_predictions"], dim=0
-        )
-        target_predictor_model_outputs = torch.stack(
-            [getattr(axl, axl_field) for axl in predictor_model_outputs], dim=0
-        )
-        torch.testing.assert_close(predictor_mo_i, target_predictor_model_outputs)
+    assert len(predictor_step_data) == number_of_predictor_steps
+
+    for step_idx in range(number_of_predictor_steps):
+        entry = predictor_step_data[step_idx]
+        assert entry['time_step_index'] == list_time_indices[step_idx]
+        torch.testing.assert_close(entry['composition_i'], list_axl_i[step_idx])
+        torch.testing.assert_close(entry['composition_im1'], list_axl_im1[step_idx])
+        torch.testing.assert_close(entry['model_predictions_i'], predictor_model_outputs[step_idx])
 
 
-def test_record_corrector(
-    sample_trajectory,
+def test_corrector_step(
+    number_of_predictor_steps,
     number_of_corrector_steps,
-    list_times,
-    list_sigmas,
+    pickle_data,
+    list_time_indices,
     list_axl_i_corr,
     list_corrected_axl_i,
     corrector_model_outputs,
 ):
 
-    torch.testing.assert_close(
-        torch.tensor(sample_trajectory.data["corrector_time"]),
-        torch.repeat_interleave(list_times, number_of_corrector_steps),
-    )
-    torch.testing.assert_close(
-        torch.tensor(sample_trajectory.data["corrector_sigma"]),
-        torch.repeat_interleave(list_sigmas, number_of_corrector_steps),
-    )
-    for axl_field, axl_name in AXL_NAME_DICT.items():
-        corrector_i = torch.stack(
-            sample_trajectory.data[f"corrector_{axl_name}_i"], dim=0
-        )
-        target_corrector_i = torch.stack(
-            [getattr(axl, axl_field) for axl in list_axl_i_corr], dim=0
-        )
-        torch.testing.assert_close(corrector_i, target_corrector_i)
-        corrector_corrected_i = torch.stack(
-            sample_trajectory.data[f"corrector_{axl_name}_corrected_i"], dim=0
-        )
-        target_corrector_corrected_i = torch.stack(
-            [getattr(axl, axl_field) for axl in list_corrected_axl_i], dim=0
-        )
-        torch.testing.assert_close(
-            corrector_corrected_i, target_corrector_corrected_i
-        )
+    assert "corrector_step" in pickle_data
+    corrector_step_data = pickle_data["corrector_step"]
 
-        corrector_mo_i = torch.stack(
-            sample_trajectory.data[f"corrector_{axl_name}_model_predictions"], dim=0
-        )
-        target_corrector_model_outputs = torch.stack(
-            [getattr(axl, axl_field) for axl in corrector_model_outputs], dim=0
-        )
-        torch.testing.assert_close(corrector_mo_i, target_corrector_model_outputs)
+    assert len(corrector_step_data) == number_of_predictor_steps * number_of_corrector_steps
+
+    global_step_idx = 0
+    for predictor_step_idx in range(number_of_predictor_steps):
+        expected_time_index = list_time_indices[predictor_step_idx]
+
+        for corrector_step_idx in range(number_of_corrector_steps):
+            entry = corrector_step_data[global_step_idx]
+            assert entry['time_step_index'] == expected_time_index
+            torch.testing.assert_close(entry['composition_i'], list_axl_i_corr[global_step_idx])
+            torch.testing.assert_close(entry['corrected_composition_i'], list_corrected_axl_i[global_step_idx])
+            torch.testing.assert_close(entry['model_predictions_i'], corrector_model_outputs[global_step_idx])
+            global_step_idx += 1
 
 
-def test_standardize_data_and_write_pickle(
-    sample_trajectory,
-    basis_vectors,
-    list_times,
-    list_sigmas,
-    list_x_i,
-    predictor_model_outputs,
-    tmp_path,
-):
-    pickle_path = str(tmp_path / "test_pickle_path.pkl")
-    sample_trajectory.write_to_pickle(pickle_path)
-
-    with open(pickle_path, "rb") as fd:
-        standardized_data = torch.load(fd)
-
-    reordered_scores = einops.rearrange(
-        torch.stack([axl.X for axl in predictor_model_outputs], dim=0),
-        "t b n d -> b t n d",
-    )
-    reordered_relative_coordinates = einops.rearrange(list_x_i, "t b n d -> b t n d")
-
-    torch.testing.assert_close(standardized_data["unit_cell"], basis_vectors)
-    torch.testing.assert_close(standardized_data["time"], list_times)
-    torch.testing.assert_close(standardized_data["sigma"], list_sigmas)
-    torch.testing.assert_close(
-        standardized_data["relative_coordinates"], reordered_relative_coordinates
-    )
-    torch.testing.assert_close(standardized_data["normalized_scores"], reordered_scores)
-
-
-def test_reset(sample_trajectory, tmp_path):
+def test_reset(sample_trajectory):
     # We don't want to affect other tests!
     copied_sample_trajectory = deepcopy(sample_trajectory)
-    assert len(copied_sample_trajectory.data.keys()) != 0
+    assert len(copied_sample_trajectory._internal_data.keys()) != 0
     copied_sample_trajectory.reset()
-    assert len(copied_sample_trajectory.data.keys()) == 0
+    assert len(copied_sample_trajectory._internal_data.keys()) == 0


### PR DESCRIPTION
only update 1 atom during atom type update as an option &
greedy update for sample with at least 1 non-masked atom &
atom type update in corrector step

Note that we could add checks that the end of the generation to make sure all atoms transitioned to non-masked. it would be possible to have MASK atoms at the end if things go poorly.