### PR TITLE
Initial lattice diffusion modules

### DIFF
--- a/experiments/lattice_diffusion_experiments/experiments/config_mlp.yaml
+++ b/experiments/lattice_diffusion_experiments/experiments/config_mlp.yaml
@@ -1,0 +1,123 @@
+#================================================================================
+# Configuration file for a diffusion experiment where only atom-types change.
+# ===========================================================================
+# The data is inspired by SiGe 1x1x1.
+# 
+# It is assumed that this config file will be used in a pseudo-experiment
+# where the main code is patched so that only atom types will change.
+#
+#================================================================================
+exp_name: lattice_only_PSEUDO
+run_name: debug
+max_epoch: 2
+log_every_n_steps: 1
+gradient_clipping: 0.0
+accumulate_grad_batches: 1  # make this number of forward passes before doing a backprop step
+
+elements: [Fire]
+cell_dimensions: [2.0, 3.0, 4.0]
+
+# set to null to avoid setting a seed (can speed up GPU computation, but
+# results will not be reproducible)
+seed: 1234
+
+# Data: a fake dataloader will recreate the same example over and over.
+data:
+  batch_size: 1024 # batch size for everyone
+  train_batch_size: 1024 # overloaded to mean 'size of training dataset'
+  valid_batch_size: 1024 # overloaded to mean 'size of validation dataset'
+  num_workers: 0
+  max_atom: 1
+
+# architecture
+spatial_dimension: 3
+
+model:
+  loss:
+    coordinates:
+      algorithm: mse
+      lambda_weight: 0.0
+    atom_types:
+      algorithm: d3pm
+      ce_weight: 1.0
+      lambda_weight: 0.0
+    lattice_parameters:
+      algorithm: mse
+      lambda_weight: 1.0
+  score_network:
+    architecture: mlp
+    num_atom_types: 1
+    number_of_atoms: 1
+    n_hidden_dimensions: 3
+    noise_embedding_dimensions_size: 32
+    time_embedding_dimensions_size: 32
+    atom_type_embedding_dimensions_size: 8 
+    hidden_dimensions_size: 64
+    conditional_prob: 0.0
+    conditional_gamma: 2
+    condition_embedding_size: 4
+  noise:
+    total_time_steps: 100
+    sigma_min: 0.0001 
+    sigma_max: 0.2
+
+# optimizer and scheduler
+optimizer:
+  name: adamw
+  learning_rate: 0.0001
+  weight_decay: 5.0e-8
+
+
+scheduler:
+  name: CosineAnnealingLR
+  T_max: 1000
+  eta_min: 0.0
+
+# early stopping
+early_stopping:
+  metric: validation_epoch_loss
+  mode: min
+  patience: 1000
+
+model_checkpoint:
+  monitor: validation_epoch_loss
+  mode: min
+
+
+# Sampling from the generative model
+diffusion_sampling:
+  noise:
+    total_time_steps: 100
+    sigma_min: 0.0001
+    sigma_max: 0.2
+    corrector_step_epsilon: 2.0e-7
+  sampling:
+    algorithm: predictor_corrector
+    num_atom_types: 2
+    number_of_atoms: 8
+    sample_batchsize: 10
+    spatial_dimension: 3
+    number_of_corrector_steps: 0
+    one_atom_type_transition_per_step: False
+    atom_type_greedy_sampling: False
+    atom_type_transition_in_corrector: False
+    number_of_samples: 10
+    record_samples: True
+    cell_dimensions: [5.542, 5.542, 5.542]
+  metrics:
+    compute_energies: True
+    compute_structure_factor: False
+
+sampling_visualization:
+  record_every_n_epochs:  1
+  first_record_epoch: 999
+  record_trajectories: True
+  record_energies: False
+  record_structure: False
+
+oracle:
+  name: lammps
+  sw_coeff_filename: SiGe.sw
+
+logging:
+  - tensorboard

--- a/experiments/lattice_diffusion_experiments/patches/identity_noiser.py
+++ b/experiments/lattice_diffusion_experiments/patches/identity_noiser.py
@@ -1,0 +1,40 @@
+import logging
+
+import torch
+
+from diffusion_for_multi_scale_molecular_dynamics.noisers.atom_types_noiser import \
+    AtomTypesNoiser
+from diffusion_for_multi_scale_molecular_dynamics.noisers.relative_coordinates_noiser import \
+    RelativeCoordinatesNoiser
+
+logger = logging.getLogger(__name__)
+
+
+class RelativeCoordinatesIdentityNoiser(RelativeCoordinatesNoiser):
+    """Identity Noiser for the relative coordinates.
+
+    This class can be used as a stand-in that returns the identity (ie, no noising).
+    """
+
+    @staticmethod
+    def get_noisy_relative_coordinates_sample(
+        real_relative_coordinates: torch.Tensor, sigmas: torch.Tensor
+    ) -> torch.Tensor:
+        """Get noisy relative coordinates sample."""
+        logger.debug("Identity Noiser! Return input as output.")
+        return real_relative_coordinates
+
+
+class AtomTypesIdentityNoiser(AtomTypesNoiser):
+    """Identity Noiser for the atom types.
+
+    This class can be used as a stand-in that returns the identity (ie, no noising).
+    """
+
+    @staticmethod
+    def get_noisy_atom_types_sample(
+        real_onehot_atom_types: torch.Tensor, q_bar: torch.Tensor
+    ) -> torch.Tensor:
+        """Get noisy atom types sample."""
+        logger.debug("Identity Noiser! Return input as output.")
+        return torch.argmax(real_onehot_atom_types, dim=-1)

--- a/experiments/lattice_diffusion_experiments/patches/lattice_demo_dataloader.py
+++ b/experiments/lattice_diffusion_experiments/patches/lattice_demo_dataloader.py
@@ -1,0 +1,180 @@
+"""DataLoader from LAMMPS outputs for a diffusion model."""
+
+import logging
+from dataclasses import dataclass
+from typing import List, Optional
+
+import pytorch_lightning as pl
+import torch
+from torch.utils.data import DataLoader, Dataset
+
+from diffusion_for_multi_scale_molecular_dynamics.namespace import (
+    ATOM_TYPES, CARTESIAN_FORCES, CARTESIAN_POSITIONS, RELATIVE_COORDINATES, LATTICE_PARAMETERS)
+
+
+logger = logging.getLogger(__name__)
+
+
+class LatticeDemoDataset(Dataset):
+    def __init__(
+        self,
+        num_samples: int,
+        lattice_averages: List[float],
+        lattice_stddev: List[float],
+        num_atom_types: int = 1,
+        num_atoms: int = 1,
+        spatial_dimension: int = 3,
+        use_physical_positions: bool = False,
+        lattice_vectors_minimum: float = 0.1
+    ):
+        self.num_samples = num_samples
+        self.num_atom_types = num_atom_types
+        self.num_atoms = num_atoms
+        self.spatial_dimension = spatial_dimension
+        self.use_physical_positions = use_physical_positions
+        self.lattice_average = torch.tensor(lattice_averages)
+        self.lattice_stddev = torch.tensor(lattice_stddev)
+        self.lattice_minimum = lattice_vectors_minimum
+
+    def generate_lattice_parameters(self):
+        z = torch.randn(self.spatial_dimension)
+        lattice_parameters = self.lattice_average + z * self.lattice_average
+        lattice_parameters = lattice_parameters.clip(min=self.lattice_minimum)
+        num_angle_params = int(self.spatial_dimension * (self.spatial_dimension - 1) / 2)
+        lattice_parameters = torch.cat([lattice_parameters, torch.zeros(num_angle_params)])
+        return lattice_parameters
+
+    def __len__(self):
+        return self.num_samples
+
+    def __getitem__(self, idx):
+        x = {}
+        for var in [CARTESIAN_POSITIONS, RELATIVE_COORDINATES, CARTESIAN_FORCES]:
+            x[var] = torch.zeros(self.num_atoms, self.spatial_dimension)
+        if self.use_physical_positions:
+            x[RELATIVE_COORDINATES][:, 0] = torch.linspace(0, 1, self.num_atoms + 1)[:-1].view(1, -1)
+            x[CARTESIAN_POSITIONS] = x[RELATIVE_COORDINATES] * 10
+        atom_types = torch.arange(idx, idx + self.num_atoms) % self.num_atom_types
+        x[ATOM_TYPES] = atom_types
+        x[LATTICE_PARAMETERS] = self.generate_lattice_parameters()
+        x["potential_energy"] = torch.zeros(1)
+        return x
+
+
+@dataclass(kw_only=True)
+class LatticeDemoParameters:
+    """Hyper parameters for LatticeDemo dataset.
+
+    This dataset generates samples with orthogonal boxes with the three sizes generated randomly from a gaussian
+    distribution.
+    """
+
+    # Either batch_size XOR train_batch_size and valid_batch_size should be specified.
+    batch_size: Optional[int] = None
+    train_batch_size: Optional[int] = None
+    valid_batch_size: Optional[int] = None
+    num_workers: int = 0
+    max_atom: int = 1  # also acts as the chain length
+    spatial_dimension: int = 3  # the dimension of Euclidean space where atoms live. Irrelevant.
+    use_physical_positions: bool = False
+    num_atom_types: int = 1  # max atom types.
+    lattice_averages: List[float]
+    lattice_stddev: List[float]
+    train_num_samples: int = 1024
+    valid_num_samples: int = 512
+
+
+class LatticeDemoDataModule(pl.LightningDataModule):
+    """Data module class that prepares dataset parsers and instantiates data loaders."""
+
+    def __init__(
+        self,
+        hyper_params: LatticeDemoParameters,
+    ):
+        """Initialize a dataset of LAMMPS structures for training a diffusion model.
+
+        Args:
+            hyper_params: hyperparameters
+        """
+        super().__init__()
+        self.num_workers = hyper_params.num_workers
+        self.max_atom = hyper_params.max_atom  # number of atoms to pad tensors
+        self.spatial_dim = hyper_params.spatial_dimension
+        self.use_physical_positions = hyper_params.use_physical_positions
+        self.num_atom_types = hyper_params.num_atom_types
+        self.lattice_averages = hyper_params.lattice_averages
+        self.lattice_stddev = hyper_params.lattice_stddev
+        self.train_num_samples = hyper_params.train_num_samples
+        self.valid_num_samples = hyper_params.valid_num_samples
+
+        if hyper_params.batch_size is None:
+            assert (
+                hyper_params.valid_batch_size is not None
+            ), "If batch_size is None, valid_batch_size must be specified."
+            assert (
+                hyper_params.train_batch_size is not None
+            ), "If batch_size is None, train_batch_size must be specified."
+
+            self.train_batch_size = hyper_params.train_batch_size
+            self.valid_batch_size = hyper_params.valid_batch_size
+
+        else:
+            assert (
+                hyper_params.valid_batch_size is None
+            ), "If batch_size is specified, valid_batch_size must be None."
+            assert (
+                hyper_params.train_batch_size is None
+            ), "If batch_size is specified, train_batch_size must be None."
+            self.train_batch_size = hyper_params.batch_size
+            self.valid_batch_size = hyper_params.batch_size
+
+    def setup(self, stage: Optional[str] = None):
+        """Parse and split all samples across the train/valid/test parsers."""
+        # here, we will actually assign train/val datasets for use in dataloaders
+        if stage == "fit" or stage is None:
+            self.train_dataset = LatticeDemoDataset(
+                num_samples=self.train_num_samples,
+                num_atom_types=self.num_atom_types,
+                num_atoms=self.max_atom,
+                spatial_dimension=self.spatial_dim,
+                use_physical_positions=self.use_physical_positions,
+                lattice_averages=self.lattice_averages,
+                lattice_stddev=self.lattice_stddev
+            )
+
+            self.valid_dataset = LatticeDemoDataset(
+                num_samples=self.valid_num_samples,
+                num_atom_types=self.num_atom_types,
+                num_atoms=self.max_atom,
+                spatial_dimension=self.spatial_dim,
+                use_physical_positions=self.use_physical_positions,
+                lattice_averages=self.lattice_averages,
+                lattice_stddev=self.lattice_stddev
+            )
+        else:
+            raise NotImplementedError("Test mode needs to be implemented.")
+
+    def train_dataloader(self) -> DataLoader:
+        """Create the training dataloader using the training data parser."""
+        return DataLoader(
+            self.train_dataset,
+            batch_size=self.train_batch_size,
+            shuffle=True,
+            num_workers=self.num_workers,
+        )
+
+    def val_dataloader(self):
+        """Create the validation dataloader using the validation data parser."""
+        return DataLoader(
+            self.valid_dataset,
+            batch_size=self.valid_batch_size,
+            shuffle=False,
+            num_workers=self.num_workers,
+        )
+
+    def test_dataloader(self):
+        """Creates the testing dataloader using the testing data parser."""
+        raise NotImplementedError("Test set is not defined at the moment.")
+
+    def clean_up(self):
+        pass

--- a/experiments/lattice_diffusion_experiments/pseudo_train_diffusion.py
+++ b/experiments/lattice_diffusion_experiments/pseudo_train_diffusion.py
@@ -1,0 +1,95 @@
+import sys  # noqa
+from pathlib import Path
+from typing import Optional
+from unittest.mock import patch  # noqa
+
+from patches.identity_noiser import (AtomTypesIdentityNoiser,
+                                     RelativeCoordinatesIdentityNoiser)
+from patches.lattice_demo_dataloader import LatticeDemoDataModule  # noqa
+from patches.lattice_demo_dataloader import LatticeDemoParameters
+
+from diffusion_for_multi_scale_molecular_dynamics import ROOT_DIR  # noqa
+from diffusion_for_multi_scale_molecular_dynamics.data.diffusion.data_loader import \
+    LammpsLoaderParameters
+from diffusion_for_multi_scale_molecular_dynamics.train_diffusion import \
+    main as train_diffusion_main  # noqa
+
+sys.path.append(str(ROOT_DIR / "../experiments/lattice_diffusion_experiments/patches"))
+
+LATTICE_AVERAGE = [2.0, 3.0, 4.0]
+LATTICE_STD = [0.2, 0.3, 0.4]
+NUM_TRAIN_SAMPLES = 1024
+NUM_VALID_SAMPLES = 512
+
+EXP_PATH = Path("/Users/simonblackburn/projects/courtois2024/experiments/lattice_diffusion_experiments/experiments")
+CONFIG_PATH = EXP_PATH / "config_mlp.yaml"
+OUTPUT_PATH = EXP_PATH / "output"
+
+
+def lattice_dm_wrapper(
+    lammps_run_dir: str,
+    processed_dataset_dir: str,
+    hyper_params: LammpsLoaderParameters,
+    working_cache_dir: Optional[str] = None,
+):
+    """This replaces the arguments from the normal datamodule to the experiment one."""
+    lattice_dm_data = LatticeDemoParameters(
+        batch_size=hyper_params.batch_size,
+        num_workers=hyper_params.num_workers,
+        max_atom=hyper_params.max_atom,
+        spatial_dimension=hyper_params.spatial_dimension,
+        use_physical_positions=False,
+        num_atom_types=len(hyper_params.elements),
+        lattice_averages=LATTICE_AVERAGE,
+        lattice_stddev=LATTICE_STD,
+        train_num_samples=NUM_TRAIN_SAMPLES,
+        valid_num_samples=NUM_VALID_SAMPLES,
+    )
+    datamodule = LatticeDemoDataModule(lattice_dm_data)
+    return datamodule
+
+
+if __name__ == "__main__":
+    # We must patch 'where the class is looked up', not where it is defined.
+    # See: https://docs.python.org/3/library/unittest.mock.html#where-to-patch
+
+    # Patch the dataloader to use the lattice diffusion experimental one.
+    target_dm = "diffusion_for_multi_scale_molecular_dynamics.train_diffusion.LammpsForDiffusionDataModule"
+
+    # Patch the noiser to never change the relative coordinates"
+    target_x_noiser = (
+        "diffusion_for_multi_scale_molecular_dynamics.models."
+        "axl_diffusion_lightning_model.RelativeCoordinatesNoiser"
+    )
+
+    # Patch the noiser to never change the atom types.
+    target_a_noiser = (
+        "diffusion_for_multi_scale_molecular_dynamics.models."
+        "axl_diffusion_lightning_model.AtomTypesNoiser"
+    )
+
+    # Patch the generator to never change the relative coordinates"
+    # TODO
+    # target3 = "diffusion_for_multi_scale_molecular_dynamics.generators.instantiate_generator.LangevinGenerator"
+
+    args = [
+        "--accelerator",
+        "cpu",
+        "--config",
+        CONFIG_PATH,
+        "--data",
+        "./",
+        "--processed_datadir",
+        "./",
+        "--dataset_working_dir",
+        "./",
+        "--output",
+        OUTPUT_PATH,
+    ]
+
+    with (
+        patch(target=target_dm, new=lattice_dm_wrapper),
+        patch(target=target_x_noiser, new=RelativeCoordinatesIdentityNoiser),
+        patch(target=target_a_noiser, new=AtomTypesIdentityNoiser),
+    ):
+        train_diffusion_main(args)

--- a/src/diffusion_for_multi_scale_molecular_dynamics/loss/__init__.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/loss/__init__.py
@@ -2,16 +2,12 @@ from diffusion_for_multi_scale_molecular_dynamics.loss.atom_type_loss_calculator
     D3PMLossCalculator
 from diffusion_for_multi_scale_molecular_dynamics.loss.coordinates_loss_calculator import (
     MSELossCalculator, WeightedMSELossCalculator)
-from diffusion_for_multi_scale_molecular_dynamics.loss.lattice_loss_calculator import \
-    LatticeLossCalculator
-from diffusion_for_multi_scale_molecular_dynamics.loss.loss_parameters import \
-    LossParameters
 from diffusion_for_multi_scale_molecular_dynamics.namespace import AXL
 
 LOSS_BY_ALGO = dict(mse=MSELossCalculator, weighted_mse=WeightedMSELossCalculator)
 
 
-def create_loss_calculator(loss_parameters: LossParameters) -> AXL:
+def create_loss_calculator(loss_parameters: AXL) -> AXL:
     """Create Loss Calculator.
 
     This is a factory method to create the loss calculator.
@@ -22,14 +18,21 @@ def create_loss_calculator(loss_parameters: LossParameters) -> AXL:
     Returns:
         loss_calculator : the loss calculator for atom types, coordinates, lattice in an AXL namedtuple.
     """
-    algorithm = loss_parameters.coordinates_algorithm
+    coordinates_algorithm = loss_parameters.X.algorithm
     assert (
-        algorithm in LOSS_BY_ALGO.keys()
-    ), f"Algorithm {algorithm} is not implemented. Possible choices are {LOSS_BY_ALGO.keys()}"
+        coordinates_algorithm in LOSS_BY_ALGO.keys()
+    ), f"Algorithm {coordinates_algorithm} is not implemented. Possible choices are {LOSS_BY_ALGO.keys()}"
 
-    coordinates_loss = LOSS_BY_ALGO[algorithm](loss_parameters)
-    lattice_loss = LatticeLossCalculator  # TODO placeholder
-    atom_loss = D3PMLossCalculator(loss_parameters)
+    lattice_algorithm = loss_parameters.L.algorithm
+    assert (
+        lattice_algorithm in LOSS_BY_ALGO.keys()
+    ), f"Algorithm {lattice_algorithm} is not implemented. Possible choices are {LOSS_BY_ALGO.keys()}"
+
+    coordinates_loss = LOSS_BY_ALGO[coordinates_algorithm](loss_parameters.X)
+    lattice_loss = LOSS_BY_ALGO[lattice_algorithm](
+        loss_parameters.L
+    )  # TODO placeholder
+    atom_loss = D3PMLossCalculator(loss_parameters.A)
 
     return AXL(
         A=atom_loss,

--- a/src/diffusion_for_multi_scale_molecular_dynamics/loss/lattice_loss_calculator.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/loss/lattice_loss_calculator.py
@@ -1,16 +1,14 @@
-import torch
+from diffusion_for_multi_scale_molecular_dynamics.loss.coordinates_loss_calculator import \
+    CoordinatesLossCalculator
 
 
-class LatticeLossCalculator(torch.nn.Module):
+class LatticeLossCalculator(CoordinatesLossCalculator):
     """Class to calculate the loss for the lattice vectors.
 
-    Placeholder for now.
+    The loss for the lattice parameters is the same as for the coordinates. We simply inherit from the coordinates loss.
+    This is an empty shell for now - we could revisit this to create a different loss for the lattice parameters.
     """
 
     def __init__(self):
         """Placeholder for now."""
         super().__init__()
-
-    def calculate_unreduced_loss(self, *args):
-        """Placeholder for now."""
-        return 0

--- a/src/diffusion_for_multi_scale_molecular_dynamics/loss/loss_parameters.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/loss/loss_parameters.py
@@ -1,10 +1,9 @@
 from dataclasses import dataclass
 from typing import Any, Dict
 
+from diffusion_for_multi_scale_molecular_dynamics.namespace import AXL
 from diffusion_for_multi_scale_molecular_dynamics.utils.configuration_parsing import \
     create_parameters_from_configuration_dictionary
-from diffusion_for_multi_scale_molecular_dynamics.namespace import AXL, AXL_NAME_DICT
-from experiments.sampling_sota_model.sota_score_sampling_and_plotting import atom_types
 
 
 @dataclass(kw_only=True)
@@ -36,11 +35,10 @@ class WeightedMSELossParameters(LossParameters):
 
 @dataclass(kw_only=True)
 class AtomTypeLossParameters(LossParameters):
-    algorithm = "d3pm"
-    atom_types_ce_weight: float = 0.001  # default value in google D3PM repo
-    atom_types_eps: float = 1e-8  # avoid divisions by zero
+    algorithm: str = "d3pm"
+    ce_weight: float = 0.001  # default value in google D3PM repo
+    eps: float = 1e-8  # avoid divisions by zero
     # https://github.com/google-research/google-research/blob/master/d3pm/images/config.py
-
 
 
 def create_loss_parameters(model_dictionary: Dict[str, Any]) -> AXL:
@@ -59,7 +57,7 @@ def create_loss_parameters(model_dictionary: Dict[str, Any]) -> AXL:
     default_axl_dict = dict(
         coordinates=default_mse_dict,
         atom_types=default_d3pm_dict,
-        lattice_parameters=default_mse_dict
+        lattice_parameters=default_mse_dict,
     )
     loss_config_dictionary = model_dictionary.get("loss", default_axl_dict)
 
@@ -70,16 +68,18 @@ def create_loss_parameters(model_dictionary: Dict[str, Any]) -> AXL:
             configuration=loss_config_dictionary.get(var, default_params),
             identifier="algorithm",
             options=LOSS_PARAMETERS_BY_ALGO,
-    )
+        )
     loss_parameters = AXL(
         A=loss_parameters["atom_types"],
         X=loss_parameters["coordinates"],
-        L=loss_parameters["lattice_parameters"]
+        L=loss_parameters["lattice_parameters"],
     )
 
     return loss_parameters
 
 
 LOSS_PARAMETERS_BY_ALGO = dict(
-    mse=MSELossParameters, weighted_mse=WeightedMSELossParameters, d3pm=AtomTypeLossParameters
+    mse=MSELossParameters,
+    weighted_mse=WeightedMSELossParameters,
+    d3pm=AtomTypeLossParameters,
 )

--- a/src/diffusion_for_multi_scale_molecular_dynamics/models/axl_diffusion_lightning_model.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/models/axl_diffusion_lightning_model.py
@@ -387,14 +387,16 @@ class AXLDiffusionLightningModel(pl.LightningModule):
         aggregated_weighted_loss = (
             self.loss_weights.X
             * unreduced_loss_coordinates.mean(
-                dim=-1
+                dim=(-2, -1)
             )  # batch, num_atoms, spatial_dimension
             + self.loss_weights.L
             * unreduced_loss_lattice.mean(
                 dim=-1
             )  # batch, spatial_dimension  TODO add angles
             + self.loss_weights.A
-            * unreduced_loss_atom_types.mean(dim=-1)  # batch, num_atoms, num_atom_types
+            * unreduced_loss_atom_types.mean(
+                dim=(-2, -1)
+            )  # batch, num_atoms, num_atom_types
         )
 
         weighted_loss = torch.mean(aggregated_weighted_loss)

--- a/src/diffusion_for_multi_scale_molecular_dynamics/models/axl_diffusion_lightning_model.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/models/axl_diffusion_lightning_model.py
@@ -486,7 +486,6 @@ class AXLDiffusionLightningModel(pl.LightningModule):
             target normalized score: sigma times target score, ie, sigma times nabla_lt log P_{t|0}(lt| l0).
                 Tensor of dimensions [batch_size, spatial_dimension * (spatial_dimension + 1) / 2]
         """
-        delta_relative_coordinates = noisy_lattice_parameters - real_lattice_parameters
         target_normalized_scores = get_lattice_sigma_normalized_score(
             noisy_lattice_parameters, real_lattice_parameters, sigmas_n, alpha_bars
         )

--- a/src/diffusion_for_multi_scale_molecular_dynamics/models/instantiate_diffusion_model.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/models/instantiate_diffusion_model.py
@@ -17,7 +17,8 @@ from diffusion_for_multi_scale_molecular_dynamics.models.score_networks.score_ne
     create_score_network_parameters
 from diffusion_for_multi_scale_molecular_dynamics.noise_schedulers.noise_parameters import \
     NoiseParameters
-from diffusion_for_multi_scale_molecular_dynamics.noisers.lattice_noiser import LatticeDataParameters
+from diffusion_for_multi_scale_molecular_dynamics.noisers.lattice_noiser import \
+    LatticeDataParameters
 from diffusion_for_multi_scale_molecular_dynamics.oracle.energy_oracle_factory import \
     create_energy_oracle_parameters
 from diffusion_for_multi_scale_molecular_dynamics.sampling.diffusion_sampling_parameters import \
@@ -39,7 +40,7 @@ def load_diffusion_model(hyper_params: Dict[AnyStr, Any]) -> AXLDiffusionLightni
     globals_dict = dict(
         max_atom=hyper_params["data"]["max_atom"],
         spatial_dimension=hyper_params.get("spatial_dimension", 3),
-        elements=elements
+        elements=elements,
     )
 
     score_network_dict = hyper_params["model"]["score_network"]
@@ -62,12 +63,15 @@ def load_diffusion_model(hyper_params: Dict[AnyStr, Any]) -> AXLDiffusionLightni
 
     oracle_parameters = None
     if "oracle" in hyper_params:
-        oracle_parameters = create_energy_oracle_parameters(hyper_params["oracle"], elements)
+        oracle_parameters = create_energy_oracle_parameters(
+            hyper_params["oracle"], elements
+        )
 
     # TODO these should come from the dataset, not the config file
     lattice_parameters = dict(
         spatial_dimension=globals_dict["spatial_dimension"],
-        inverse_average_density=globals_dict["max_atom"] / torch.prod(hyper_params["cell_dimensions"])
+        inverse_average_density=globals_dict["max_atom"]
+        / torch.prod(torch.tensor(hyper_params["cell_dimensions"])),
     )  # TODO inverse density should come from the dataset, not fixed like this
     lattice_parameters = LatticeDataParameters(**lattice_parameters)
 
@@ -79,7 +83,7 @@ def load_diffusion_model(hyper_params: Dict[AnyStr, Any]) -> AXLDiffusionLightni
         noise_parameters=noise_parameters,
         diffusion_sampling_parameters=diffusion_sampling_parameters,
         oracle_parameters=oracle_parameters,
-        lattice_parameters=lattice_parameters
+        lattice_parameters=lattice_parameters,
     )
 
     model = AXLDiffusionLightningModel(diffusion_params)

--- a/src/diffusion_for_multi_scale_molecular_dynamics/models/score_networks/analytical_score_network.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/models/score_networks/analytical_score_network.py
@@ -23,7 +23,7 @@ from diffusion_for_multi_scale_molecular_dynamics.models.score_networks.score_ne
 from diffusion_for_multi_scale_molecular_dynamics.namespace import (
     AXL, NOISE, NOISY_AXL_COMPOSITION)
 from diffusion_for_multi_scale_molecular_dynamics.score.wrapped_gaussian_score import \
-    get_sigma_normalized_score
+    get_coordinates_sigma_normalized_score
 from diffusion_for_multi_scale_molecular_dynamics.utils.basis_transformations import \
     map_relative_coordinates_to_unit_cell
 
@@ -276,7 +276,7 @@ class TargetScoreBasedAnalyticalScoreNetwork(AnalyticalScoreNetwork):
         broadcast_effective_sigmas = (broadcast_sigmas**2 + self.sigma_d_square).sqrt()
 
         delta_relative_coordinates = map_relative_coordinates_to_unit_cell(xt - self.x0)
-        misnormalized_scores = get_sigma_normalized_score(
+        misnormalized_scores = get_coordinates_sigma_normalized_score(
             delta_relative_coordinates, broadcast_effective_sigmas, kmax=self.kmax
         )
 

--- a/src/diffusion_for_multi_scale_molecular_dynamics/models/score_networks/mlp_score_network.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/models/score_networks/mlp_score_network.py
@@ -56,6 +56,9 @@ class MLPScoreNetwork(ScoreNetwork):
 
         coordinate_output_dimension = self.spatial_dimension * self._natoms
         atom_type_output_dimension = self._natoms * self.num_classes
+        lattice_parameters_output_dimension = int(
+            self.spatial_dimension * (self.spatial_dimension + 1) / 2
+        )
 
         input_dimension = (
             coordinate_output_dimension
@@ -96,12 +99,18 @@ class MLPScoreNetwork(ScoreNetwork):
         self.non_linearity = nn.ReLU()
 
         # Create a self nn object to be discoverable to be placed on the correct device
-        self.output_A_layer = nn.Linear(hyper_params.hidden_dimensions_size, atom_type_output_dimension)
-        self.output_X_layer = nn.Linear(hyper_params.hidden_dimensions_size, coordinate_output_dimension)
-        self.output_L_layer = nn.Identity()
-        self.output_layers = AXL(A=self.output_A_layer,
-                                 X=self.output_X_layer,
-                                 L=self.output_L_layer)  # TODO placeholder
+        self.output_A_layer = nn.Linear(
+            hyper_params.hidden_dimensions_size, atom_type_output_dimension
+        )
+        self.output_X_layer = nn.Linear(
+            hyper_params.hidden_dimensions_size, coordinate_output_dimension
+        )
+        self.output_L_layer = nn.Linear(
+            hyper_params.hidden_dimensions_size, lattice_parameters_output_dimension
+        )
+        self.output_layers = AXL(
+            A=self.output_A_layer, X=self.output_X_layer, L=self.output_L_layer
+        )
 
     def _check_batch(self, batch: Dict[AnyStr, torch.Tensor]):
         super(MLPScoreNetwork, self)._check_batch(batch)
@@ -147,6 +156,8 @@ class MLPScoreNetwork(ScoreNetwork):
             atom_types_one_hot
         )  # shape [batch_size, atom_type_embedding_dimension]
 
+        # TODO lattice parameters should be used here
+
         input = torch.cat(
             [
                 self.flatten(relative_coordinates),
@@ -177,7 +188,7 @@ class MLPScoreNetwork(ScoreNetwork):
         atom_types_output = self.output_layers.A(output).reshape(
             atom_types_one_hot.shape
         )
-        lattice_output = torch.zeros_like(atom_types_output)  # TODO placeholder
+        lattice_output = self.output_L_layer(output)
 
         axl_output = AXL(A=atom_types_output, X=coordinates_output, L=lattice_output)
         return axl_output

--- a/src/diffusion_for_multi_scale_molecular_dynamics/namespace.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/namespace.py
@@ -29,8 +29,11 @@ UNIT_CELL = "unit_cell"  # unit cell definition
 ATOM_TYPES = "atom_types"
 NOISY_ATOM_TYPES = "noisy_atom_types"
 
+LATTICE_PARAMETERS = "lattice_parameters"
+NOISY_LATTICE_PARAMETERS = "noisy_lattice_parameters"
+
 AXL = namedtuple("AXL", ["A", "X", "L"])
-AXL_NAME_DICT = {"A": ATOM_TYPES, "X": RELATIVE_COORDINATES, "L": UNIT_CELL}
+AXL_NAME_DICT = {"A": ATOM_TYPES, "X": RELATIVE_COORDINATES, "L": LATTICE_PARAMETERS}
 
 NOISY_AXL_COMPOSITION = "noisy_axl"
 AXL_COMPOSITION = "original_axl"

--- a/src/diffusion_for_multi_scale_molecular_dynamics/noisers/lattice_noiser.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/noisers/lattice_noiser.py
@@ -1,4 +1,17 @@
+from dataclasses import dataclass
+from typing import Tuple
+
 import torch
+
+
+@dataclass(kw_only=True)
+class LatticeDataParameters:
+    """Information on the mean of the lattice parameters used for noising a sample.
+
+    TODO: this might belong elsewhere
+    """
+    inverse_average_density: float  # inverse of the average volume of unit cell scales by the number of atoms
+    spatial_dimension: int = 3
 
 
 class LatticeNoiser:
@@ -7,17 +20,71 @@ class LatticeNoiser:
     This class provides methods to generate noisy lattices.
     TODO this is a placeholder
     """
+    def __init__(self, lattice_parameters: LatticeDataParameters):
+        self.inverse_density = lattice_parameters.inverse_average_density
+        self.spatial_dimension = lattice_parameters.spatial_dimension
 
     @staticmethod
-    def get_noisy_lattice_vectors(real_lattice_vectors: torch.Tensor) -> torch.Tensor:
-        """Get noisy lattice vectors.
+    def _get_gaussian_noise(shape: Tuple[int]) -> torch.Tensor:
+        """Get Gaussian noise.
 
-        TODO this is a placeholder
+        Get a sample from N(0, 1) of dimensions shape.
 
         Args:
-            real_lattice_vectors: lattice vectors from the sampled data
+            shape : the shape of the sample.
 
         Returns:
-            real_lattice_vectors: a sample of noised lattice vectors. Placeholder for now.
+            gaussian_noise: a sample from N(0, 1) of dimensions shape.
         """
-        return real_lattice_vectors
+        return torch.randn(shape)
+
+    def get_noisy_lattice_vectors(
+        self,
+        real_lattice_parameters: torch.Tensor,
+        sigmas_n: torch.Tensor,
+        alpha_bars: torch.Tensor,
+        num_atoms: torch.Tensor,
+    ) -> torch.Tensor:
+        r"""Get noisy lattice vectors.
+
+        We consider the lattice parameters as a tensor of spatial_dimension degrees of freedom i.e. we assume the unit
+        cell is orthogonal.
+
+        .. math::
+
+            q(L_t | L_0) = \mathcal{N}\left(\sqrt{\bar{\alpha}_t}L_0 +
+                (1 - \sqrt{\bar{\alpha}_t})\mu(n)I, (1-\sqrt{\bar{\alpha}_t})\sigma^2_t(n)I\right)
+
+        Args:
+            real_lattice_parameters: lattice parameters from the sampled data. This is not the lattice vector, but an
+                array of dimension [spatial_dimension] containing the size of the orthogonal box. TODO add angles
+            sigmas_n: variance of the perturbation kernel rescaled by the number of atoms. Tensor is assumed to be of
+                the same shape as real_lattice_parameters.
+            alpha_bars: cumulative noise scale. Tensor is assumed to be of the same shape as real_lattice_parameters.
+            num_atoms: number of atoms in each sample. Tensor should be a 1D tensor matching the first dimension of the
+                real_lattice_parameters tensor.
+
+        Returns:
+            noisy_lattice_parameters: a sample of noised lattice vectors as tensor of size [spatial_dimension].
+        """
+        # TODO add angles
+        assert (
+                real_lattice_parameters.shape == sigmas_n.shape
+        ), "sigmas array is expected to be of the same shape as the real_lattice_parameters array"
+
+        assert (
+                alpha_bars.shape == sigmas_n.shape
+        ), "sigmas array is expected to be of the same shape as the alpha_bars array"
+
+        z_scores = LatticeNoiser._get_gaussian_noise(
+            real_lattice_parameters.shape
+        ).to(sigmas_n)
+
+        noise_width = (1 - alpha_bars) * sigmas_n ** 2
+        sqrt_alpha_bars = torch.sqrt(alpha_bars)
+        average_density = torch.pow(num_atoms / self.inverse_density, 1 / self.spatial_dimension)
+        noisy_lattice_parameters_avg = sqrt_alpha_bars * real_lattice_parameters + \
+                                       (1 - sqrt_alpha_bars) * average_density
+        noisy_lattice_parameters = noise_width * z_scores + noisy_lattice_parameters_avg
+
+        return noisy_lattice_parameters

--- a/src/diffusion_for_multi_scale_molecular_dynamics/noisers/lattice_noiser.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/noisers/lattice_noiser.py
@@ -3,9 +3,6 @@ from typing import Tuple
 
 import torch
 
-from experiments.analysis.analytic_score.repaint.plot_repaint_analytical_score_trajectories import \
-    spatial_dimension
-
 
 @dataclass(kw_only=True)
 class LatticeDataParameters:
@@ -61,8 +58,9 @@ class LatticeNoiser:
                 (1 - \sqrt{\bar{\alpha}_t})\mu(n)I, (1-\sqrt{\bar{\alpha}_t})\sigma^2_t(n)I\right)
 
         Args:
-            real_lattice_parameters: lattice parameters from the sampled data. This is not the lattice vector, but an
-                array of dimension [spatial_dimension] containing the size of the orthogonal box. TODO add angles
+            real_lattice_parameters: lattice parameters from the sampled data. These parameters are not the lattice
+                vector, but an array of dimension [spatial_dimension] containing the size of the orthogonal box.
+                TODO add angles
             sigmas_n: variance of the perturbation kernel rescaled by the number of atoms. Tensor is assumed to be of
                 the same shape as real_lattice_parameters.
             alpha_bars: cumulative noise scale. Tensor is assumed to be of the same shape as real_lattice_parameters.
@@ -70,7 +68,7 @@ class LatticeNoiser:
                 real_lattice_parameters tensor.
 
         Returns:
-            noisy_lattice_parameters: a sample of noised lattice vectors as tensor of size [spatial_dimension].
+            noisy_lattice_parameters: a sample of noised lattice parameters as tensor of size [spatial_dimension].
         """
         # TODO add angles
         assert (

--- a/src/diffusion_for_multi_scale_molecular_dynamics/score/gaussian_score.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/score/gaussian_score.py
@@ -9,11 +9,8 @@ The Gaussian takes the form
 
 The score is defined as S = nabla_l ln K(l, l0).
 """
-import numpy as np
-import torch
 
-from diffusion_for_multi_scale_molecular_dynamics.score.wrapped_gaussian_score import \
-    get_coordinates_sigma_normalized_score
+import torch
 
 
 def get_lattice_sigma_normalized_score(
@@ -21,9 +18,8 @@ def get_lattice_sigma_normalized_score(
 ) -> torch.Tensor:
     r"""Get the sigma normalized score for lattice parameters.
 
-    We compute this from a normal (non-wrapped) gaussian kernel, which we can get by calling a wrapped gaussian kernel
-    with k_max = 0 (which effectively removes the sum). Because we are using a variance-preserving approach for the
-    lattice parameters, the width of the gaussian kernel is rescaled by the noise parameter :math:`alpha_bar`.
+    We compute this from a normal (non-wrapped) gaussian kernel.  Because we are using a variance-preserving approach
+    for the lattice parameters, the width of the gaussian kernel is rescaled by the noise parameter :math:`alpha_bar`.
 
     .. math::
 
@@ -37,15 +33,15 @@ def get_lattice_sigma_normalized_score(
         alpha_bar : the cumulative variance in the definition of the variance-preserving diffusion.
 
     Returns:
-        sigma_normalized_score : the value of the sigma normalized score.
+        sigma_score : the value of the sigma normalized score.
     """
     # rescale sigma by 1 - alpha_bar
-    sigma_effective = np.sqrt(1 - alpha_bar) * sigma_n
-    # we can get the sigma normalized score using the wrapped gaussian method with k_max = 0 i.e. no sum
-    # and using the effective sigma computed
-    sigma_normalized_score = get_coordinates_sigma_normalized_score(
-        delta_l,
-        sigma_effective,
-        kmax=0
-    )
-    return sigma_normalized_score
+    sigma_effective = torch.sqrt(1 - alpha_bar) * sigma_n
+
+    # we can get the sigma normalized score using a method similar to the brute force calculation in the wrapped
+    # gaussian kernel implementation. We do not need a sum over k as the kernel is not periodic. This simplifies to the
+    # -x / sigma
+
+    sigma_score = -delta_l / sigma_effective
+
+    return sigma_score

--- a/src/diffusion_for_multi_scale_molecular_dynamics/score/gaussian_score.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/score/gaussian_score.py
@@ -1,0 +1,50 @@
+"""Gaussian Score.
+
+This module implements the Gaussian score, which corresponds to the "perturbation kernel" for diffusion on the lattice
+parameters.
+
+The Gaussian takes the form
+
+    K(l, l0) ~ exp[- |l - l0|^2 / 2 sigma^2]
+
+The score is defined as S = nabla_l ln K(l, l0).
+"""
+import numpy as np
+
+from diffusion_for_multi_scale_molecular_dynamics.score.wrapped_gaussian_score import \
+    get_sigma_normalized_score_brute_force
+
+
+def get_lattice_sigma_normalized_score(
+    delta_l: float, sigma_n: float, alpha_bar: float
+) -> float:
+    r"""Get the sigma normalized score for lattice parameters.
+
+    We compute this from a normal (non-wrapped) gaussian kernel, which we can get by calling a wrapped gaussian kernel
+    with k_max = 0 (which effectively removes the sum). Because we are using a variance-preserving approach for the
+    lattice parameters, the width of the gaussian kernel is rescaled by the noise parameter :math:`alpha_bar`.
+
+    .. math::
+
+        \sigma_\textrm{eff}^2 = (1 - \bar{\alpha}) \sigma^2(n)
+
+    with :math:`\sigma(n) = \frac{\sigma}{\sqrt[1/d]{n}}` with :math:`d` the number of spatial dimensions.
+
+    Args:
+        delta_l : the lattice parameters at which the wrapped Gaussian is evaluated.
+        sigma_n : the variance in the definition of the variance-exploding diffusion - scaled by the number of atoms.
+        alpha_bar : the cumulative variance in the definition of the variance-preserving diffusion.
+
+    Returns:
+        sigma_normalized_score : the value of the sigma normalized score.
+    """
+    # rescale sigma by 1 - alpha_bar
+    sigma_effective = np.sqrt(1 - alpha_bar) * sigma_n
+    # we can get the sigma normalized score using the wrapped gaussian method with k_max = 0 i.e. no sum
+    # and using the effective sigma computed
+    sigma_normalized_score = get_sigma_normalized_score_brute_force(
+        delta_l,
+        sigma_effective,
+        kmax=0
+    )
+    return sigma_normalized_score

--- a/src/diffusion_for_multi_scale_molecular_dynamics/score/gaussian_score.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/score/gaussian_score.py
@@ -10,14 +10,15 @@ The Gaussian takes the form
 The score is defined as S = nabla_l ln K(l, l0).
 """
 import numpy as np
+import torch
 
 from diffusion_for_multi_scale_molecular_dynamics.score.wrapped_gaussian_score import \
-    get_sigma_normalized_score_brute_force
+    get_coordinates_sigma_normalized_score
 
 
 def get_lattice_sigma_normalized_score(
-    delta_l: float, sigma_n: float, alpha_bar: float
-) -> float:
+    delta_l: torch.Tensor, sigma_n: torch.Tensor, alpha_bar: torch.Tensor
+) -> torch.Tensor:
     r"""Get the sigma normalized score for lattice parameters.
 
     We compute this from a normal (non-wrapped) gaussian kernel, which we can get by calling a wrapped gaussian kernel
@@ -42,7 +43,7 @@ def get_lattice_sigma_normalized_score(
     sigma_effective = np.sqrt(1 - alpha_bar) * sigma_n
     # we can get the sigma normalized score using the wrapped gaussian method with k_max = 0 i.e. no sum
     # and using the effective sigma computed
-    sigma_normalized_score = get_sigma_normalized_score_brute_force(
+    sigma_normalized_score = get_coordinates_sigma_normalized_score(
         delta_l,
         sigma_effective,
         kmax=0

--- a/src/diffusion_for_multi_scale_molecular_dynamics/score/gaussian_score.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/score/gaussian_score.py
@@ -14,7 +14,7 @@ import torch
 
 
 def get_lattice_sigma_normalized_score(
-    delta_l: torch.Tensor, sigma_n: torch.Tensor, alpha_bar: torch.Tensor
+    noisy_l: torch.Tensor, real_l: torch.Tensor, sigma_n: torch.Tensor, alpha_bar: torch.Tensor
 ) -> torch.Tensor:
     r"""Get the sigma normalized score for lattice parameters.
 
@@ -28,7 +28,8 @@ def get_lattice_sigma_normalized_score(
     with :math:`\sigma(n) = \frac{\sigma}{\sqrt[1/d]{n}}` with :math:`d` the number of spatial dimensions.
 
     Args:
-        delta_l : the lattice parameters at which the wrapped Gaussian is evaluated.
+        noisy_l : the noised lattice parameters used to evaluate the Gaussian score.
+        real_l: the real (non-noised) lattice parameters to evaluate the Gaussian score.
         sigma_n : the variance in the definition of the variance-exploding diffusion - scaled by the number of atoms.
         alpha_bar : the cumulative variance in the definition of the variance-preserving diffusion.
 
@@ -41,7 +42,7 @@ def get_lattice_sigma_normalized_score(
     # we can get the sigma normalized score using a method similar to the brute force calculation in the wrapped
     # gaussian kernel implementation. We do not need a sum over k as the kernel is not periodic. This simplifies to the
     # -x / sigma
-
-    sigma_score = -delta_l / sigma_effective
+    # note that the lattice score rescales L_0 (the real lattice parameters) by a factor :math:`\sqrt{\bar{\alpha}}`.
+    sigma_score = -(noisy_l - torch.sqrt(alpha_bar) * real_l) / sigma_effective
 
     return sigma_score

--- a/src/diffusion_for_multi_scale_molecular_dynamics/score/wrapped_gaussian_score.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/score/wrapped_gaussian_score.py
@@ -74,7 +74,10 @@ def get_sigma_normalized_score_brute_force(
 
 
 def get_coordinates_sigma_normalized_score(
-    relative_coordinates: torch.Tensor, sigmas: torch.Tensor, kmax: int
+    relative_coordinates: torch.Tensor,
+    sigmas: torch.Tensor,
+    kmax: int,
+    coordinates_bounded: bool = True,
 ) -> torch.Tensor:
     """Get the sigma normalized score for relative coordinates from the wrapped gaussian kernel.
 
@@ -86,6 +89,8 @@ def get_coordinates_sigma_normalized_score(
             relative_coordinates is assumed to have an arbitrary shape.
         sigmas : the values of sigma. Should have the same dimension as relative coordinates.
         kmax : largest positive integer in the sum. The sum is from -kmax to +kmax.
+        coordinates_bounded: if True, check that the relative coordinates are between 0 and 1. Ignore that check
+            otherwise. Defaults to True.
 
     Returns:
         list_sigma_normalized_score : the sigma_normalized_scores, in the same shape as
@@ -93,9 +98,10 @@ def get_coordinates_sigma_normalized_score(
     """
     assert kmax >= 0, "kmax must be a non negative integer"
     assert (sigmas > 0).all(), "All values of sigma should be larger than zero."
-    assert torch.logical_and(
-        relative_coordinates >= 0, relative_coordinates < 1
-    ).all(), "the relative coordinates should all be in [0, 1)"
+    if coordinates_bounded:
+        assert torch.logical_and(
+            relative_coordinates >= 0, relative_coordinates < 1
+        ).all(), "the relative coordinates should all be in [0, 1)"
     assert (
         sigmas.shape == relative_coordinates.shape
     ), "The relative_coordinates and sigmas inputs should have the same shape"

--- a/src/diffusion_for_multi_scale_molecular_dynamics/score/wrapped_gaussian_score.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/score/wrapped_gaussian_score.py
@@ -73,10 +73,10 @@ def get_sigma_normalized_score_brute_force(
     return sigma_score
 
 
-def get_sigma_normalized_score(
+def get_coordinates_sigma_normalized_score(
     relative_coordinates: torch.Tensor, sigmas: torch.Tensor, kmax: int
 ) -> torch.Tensor:
-    """Get the sigma normalized score.
+    """Get the sigma normalized score for relative coordinates from the wrapped gaussian kernel.
 
     This method branches to different formulas depending on the values of sigma and relative coordinates
     to insures rapid convergence and numerical stability.

--- a/src/diffusion_for_multi_scale_molecular_dynamics/utils/basis_transformations.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/utils/basis_transformations.py
@@ -2,6 +2,7 @@ import numpy as np
 import torch
 
 from diffusion_for_multi_scale_molecular_dynamics.namespace import AXL
+from experiments.analysis.analytic_score.score_convergence_analysis import spatial_dimension
 
 
 def get_reciprocal_basis_vectors(basis_vectors: torch.Tensor) -> torch.Tensor:
@@ -152,8 +153,12 @@ def map_lattice_parameters_to_unit_cell_vectors(
     Returns:
         unit_cell_vectors: unit vectors. Dimension: [..., spatial dimension, spatial dimension].
     """
-    # TODO we assume a diagonal map here
     last_dim_size = lattice_parameters.shape[-1]
     spatial_dimension = int((-1 + np.sqrt(1 + 8 * last_dim_size)) / 2)
+
+    # TODO we assume a diagonal map here  - we need to revisit this when we introduce angles in the lattice box
+    torch.allclose(lattice_parameters[..., spatial_dimension:],
+                   torch.zeros_like(lattice_parameters[..., spatial_dimension:]))
+
     vector_lengths = lattice_parameters[..., :spatial_dimension]
     return torch.diag_embed(vector_lengths)

--- a/src/diffusion_for_multi_scale_molecular_dynamics/utils/basis_transformations.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/utils/basis_transformations.py
@@ -1,3 +1,4 @@
+import numpy as np
 import torch
 
 from diffusion_for_multi_scale_molecular_dynamics.namespace import AXL
@@ -133,3 +134,26 @@ def map_axl_composition_to_unit_cell(composition: AXL, device: torch.device) -> 
         A=composition.A, X=normalized_relative_coordinates, L=composition.L
     )
     return normalized_composition
+
+
+def map_lattice_parameters_to_unit_cell_vectors(
+    lattice_parameters: torch.Tensor,
+) -> torch.Tensor:
+    """Map the lattice parameters in an AXL namedtuple back to vectors used to describe the lattice explicitly.
+
+    The lattice parameters are a set of spatial dimension x (spatial dimension + 1) / 2 variables describing the length
+    of the vectors and the angles.
+    TODO we are currently assuming the angles to be fixed at 90 degrees.
+
+    Args:
+        lattice_parameters: lattice parameters used in AXL diffusion model i.e. the vector norms and angles.
+            Dimension: [..., spatial dimension x (spatial dimension + 1) / 2]
+
+    Returns:
+        unit_cell_vectors: unit vectors. Dimension: [..., spatial dimension, spatial dimension].
+    """
+    # TODO we assume a diagonal map here
+    last_dim_size = lattice_parameters.shape[-1]
+    spatial_dimension = int((-1 + np.sqrt(1 + 8 * last_dim_size)) / 2)
+    vector_lengths = lattice_parameters[..., :spatial_dimension]
+    return torch.diag_embed(vector_lengths)

--- a/src/diffusion_for_multi_scale_molecular_dynamics/utils/noise_utils.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/utils/noise_utils.py
@@ -5,5 +5,25 @@ def scale_sigma_by_number_of_atoms(
     sigma: torch.Tensor,
     number_of_atoms: torch.Tensor,
     spatial_dimension: int
-):
-    return sigma * torch.pow(number_of_atoms, 1 / spatial_dimension)
+) -> torch.Tensor:
+    r"""Scale noise factor by the number of atoms.
+
+    The variance of the noise distribution for cartesian coordinates depends on the size of the unit cell. If we assume
+    the volume of a unit cell is proportional to the number of atoms, we can mitigate this variance by rescaling the
+    factor :math:`\sigma` in the relative coordinates space by the number of atoms.
+
+    .. math::
+
+        \sigma(n) = \frac{\sigma}{\sqrt[d]n}
+
+    with :math:`d`  the number of spatial dimensions.
+
+    Args:
+        sigma: unscaled noise factor :math:`\sigma` as a [batch_size, ...] tensor
+        number_of_atoms: number of atoms in the unit cell as a [batch_size, ...] tensor
+        spatial_dimension: number of spatial dimensions
+
+    Returns:
+        sigma_n : scaled sigma
+    """
+    return sigma / torch.pow(number_of_atoms, 1 / spatial_dimension)

--- a/src/diffusion_for_multi_scale_molecular_dynamics/utils/noise_utils.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/utils/noise_utils.py
@@ -1,0 +1,9 @@
+import torch
+
+
+def scale_sigma_by_number_of_atoms(
+    sigma: torch.Tensor,
+    number_of_atoms: torch.Tensor,
+    spatial_dimension: int
+):
+    return sigma * torch.pow(number_of_atoms, 1 / spatial_dimension)

--- a/tests/loss/test_atom_type_loss_calculator.py
+++ b/tests/loss/test_atom_type_loss_calculator.py
@@ -5,7 +5,7 @@ import torch
 from torch.nn import KLDivLoss
 
 from diffusion_for_multi_scale_molecular_dynamics.loss import (
-    D3PMLossCalculator, LossParameters)
+    D3PMLossCalculator, AXLLossParameters)
 from diffusion_for_multi_scale_molecular_dynamics.utils.d3pm_utils import \
     class_index_to_onehot
 from diffusion_for_multi_scale_molecular_dynamics.utils.tensor_utils import \
@@ -137,7 +137,7 @@ class TestD3PMLossCalculator:
 
     @pytest.fixture
     def loss_parameters(self, loss_eps, atom_types_ce_weight):
-        return LossParameters(
+        return AXLLossParameters(
             coordinates_algorithm=None,
             atom_types_eps=loss_eps,
             atom_types_ce_weight=atom_types_ce_weight,

--- a/tests/loss/test_atom_type_loss_calculator.py
+++ b/tests/loss/test_atom_type_loss_calculator.py
@@ -5,7 +5,8 @@ import torch
 from torch.nn import KLDivLoss
 
 from diffusion_for_multi_scale_molecular_dynamics.loss import (
-    D3PMLossCalculator, AXLLossParameters)
+    D3PMLossCalculator)
+from diffusion_for_multi_scale_molecular_dynamics.loss.loss_parameters import AtomTypeLossParameters
 from diffusion_for_multi_scale_molecular_dynamics.utils.d3pm_utils import \
     class_index_to_onehot
 from diffusion_for_multi_scale_molecular_dynamics.utils.tensor_utils import \
@@ -137,10 +138,10 @@ class TestD3PMLossCalculator:
 
     @pytest.fixture
     def loss_parameters(self, loss_eps, atom_types_ce_weight):
-        return AXLLossParameters(
-            coordinates_algorithm=None,
-            atom_types_eps=loss_eps,
-            atom_types_ce_weight=atom_types_ce_weight,
+        return AtomTypeLossParameters(
+            algorithm=None,
+            eps=loss_eps,
+            ce_weight=atom_types_ce_weight,
         )
 
     @pytest.fixture

--- a/tests/loss/test_regression_loss.py
+++ b/tests/loss/test_regression_loss.py
@@ -4,7 +4,8 @@ import torch
 from diffusion_for_multi_scale_molecular_dynamics.loss import \
     create_loss_calculator
 from diffusion_for_multi_scale_molecular_dynamics.loss.loss_parameters import (
-    MSELossParameters, WeightedMSELossParameters)
+    MSELossParameters, WeightedMSELossParameters, AtomTypeLossParameters)
+from diffusion_for_multi_scale_molecular_dynamics.namespace import AXL
 from src.diffusion_for_multi_scale_molecular_dynamics.utils.tensor_utils import \
     broadcast_batch_tensor_to_all_dimensions
 
@@ -72,7 +73,12 @@ def algorithm(request):
 
 
 @pytest.fixture()
-def loss_parameters(algorithm, sigma0, exponent):
+def atom_types_loss_params():
+    return AtomTypeLossParameters(algorithm="d3pm")
+
+
+@pytest.fixture()
+def loss_parameters(algorithm, sigma0, exponent, atom_types_loss_params):
     match algorithm:
         case "mse":
             parameters = MSELossParameters()
@@ -80,7 +86,12 @@ def loss_parameters(algorithm, sigma0, exponent):
             parameters = WeightedMSELossParameters(sigma0=sigma0, exponent=exponent)
         case _:
             raise ValueError(f"Unknown loss algorithm {algorithm}")
-    return parameters
+    axl_parameters = AXL(
+        X=parameters,
+        A=atom_types_loss_params,
+        L=parameters
+    )
+    return axl_parameters
 
 
 @pytest.fixture()

--- a/tests/models/score_network/test_analytical_score_network.py
+++ b/tests/models/score_network/test_analytical_score_network.py
@@ -81,9 +81,11 @@ class TestAnalyticalScoreNetwork(BaseTestScoreNetwork):
         times = torch.rand(batch_size, 1)
         noises = torch.rand(batch_size, 1)
         unit_cell = torch.rand(batch_size, spatial_dimension, spatial_dimension)
+        lattice_params = torch.zeros(batch_size, int(spatial_dimension * (spatial_dimension + 1) / 2))
+        lattice_params[:, :spatial_dimension] = torch.diagonal(unit_cell, dim1=-2, dim2=-1)
         return {
             NOISY_AXL_COMPOSITION: AXL(
-                A=atom_types, X=relative_coordinates, L=torch.zeros_like(atom_types)
+                A=atom_types, X=relative_coordinates, L=lattice_params
             ),
             TIME: times,
             NOISE: noises,

--- a/tests/models/score_network/test_force_field_augmented_score_network.py
+++ b/tests/models/score_network/test_force_field_augmented_score_network.py
@@ -65,6 +65,12 @@ class TestForceFieldAugmentedScoreNetwork(BaseTestScoreNetwork):
         return basis_vectors
 
     @pytest.fixture
+    def lattice_parameters(self, batch_size, spatial_dimension, basis_vectors):
+        lattice_params = torch.zeros(batch_size, int(spatial_dimension * (spatial_dimension + 1) / 2))
+        lattice_params[:, :spatial_dimension] = torch.diagonal(basis_vectors, dim1=-2, dim2=-1)
+        return lattice_params
+
+    @pytest.fixture
     def relative_coordinates(
         self, batch_size, number_of_atoms, spatial_dimension, basis_vectors
     ):
@@ -93,15 +99,16 @@ class TestForceFieldAugmentedScoreNetwork(BaseTestScoreNetwork):
         times,
         noises,
         basis_vectors,
+        lattice_parameters,
     ):
         return {
             NOISY_AXL_COMPOSITION: AXL(
                 A=atom_types,
                 X=relative_coordinates,
-                L=torch.zeros_like(atom_types),  # TODO
+                L=lattice_parameters,
             ),
             TIME: times,
-            UNIT_CELL: basis_vectors,
+            UNIT_CELL: basis_vectors,  # TODO remove this
             NOISE: noises,
             CARTESIAN_FORCES: cartesian_forces,
         }

--- a/tests/models/score_network/test_score_network_equivariance.py
+++ b/tests/models/score_network/test_score_network_equivariance.py
@@ -73,6 +73,7 @@ class BaseTestScoreEquivariance(BaseTestScoreNetwork):
         cartesian_positions,
         atom_types,
         basis_vectors,
+        lattice_parameters,
         times,
         noises,
         forces,
@@ -81,12 +82,12 @@ class BaseTestScoreEquivariance(BaseTestScoreNetwork):
             NOISY_AXL_COMPOSITION: AXL(
                 A=atom_types,
                 X=relative_coordinates,
-                L=torch.zeros_like(atom_types),  # TODO
+                L=lattice_parameters,
             ),
             NOISY_CARTESIAN_POSITIONS: cartesian_positions,
             TIME: times,
             NOISE: noises,
-            UNIT_CELL: basis_vectors,
+            UNIT_CELL: basis_vectors,  # TODO link to lattice parameters
             CARTESIAN_FORCES: forces,
         }
         return batch
@@ -164,6 +165,15 @@ class BaseTestScoreEquivariance(BaseTestScoreNetwork):
         return basis_vectors
 
     @pytest.fixture()
+    def lattice_parameters(self, basis_vectors, spatial_dimension):
+        lattice_dim = int(spatial_dimension * (spatial_dimension + 1) / 2)
+        lattice_values = torch.zeros(basis_vectors.shape[0], lattice_dim)
+        lattice_values[:, :spatial_dimension] = torch.diagonal(
+            basis_vectors, dim1=-2, dim2=-1
+        )
+        return lattice_values
+
+    @pytest.fixture()
     def rotated_basis_vectors(
         self, cartesian_rotations, basis_vectors, are_basis_vectors_rotated
     ):
@@ -233,6 +243,7 @@ class BaseTestScoreEquivariance(BaseTestScoreNetwork):
         cartesian_positions,
         atom_types,
         basis_vectors,
+        lattice_parameters,
         times,
         noises,
         forces,
@@ -242,6 +253,7 @@ class BaseTestScoreEquivariance(BaseTestScoreNetwork):
             cartesian_positions,
             atom_types,
             basis_vectors,
+            lattice_parameters,
             times,
             noises,
             forces,
@@ -255,6 +267,7 @@ class BaseTestScoreEquivariance(BaseTestScoreNetwork):
         cartesian_positions,
         atom_types,
         basis_vectors,
+        lattice_parameters,
         times,
         noises,
         forces,
@@ -275,6 +288,7 @@ class BaseTestScoreEquivariance(BaseTestScoreNetwork):
             new_cartesian_positions,
             atom_types,
             basis_vectors,
+            lattice_parameters,
             times,
             noises,
             forces,
@@ -289,6 +303,7 @@ class BaseTestScoreEquivariance(BaseTestScoreNetwork):
         cartesian_positions,
         atom_types,
         basis_vectors,
+        lattice_parameters,
         times,
         noises,
         forces,
@@ -313,6 +328,7 @@ class BaseTestScoreEquivariance(BaseTestScoreNetwork):
             new_cartesian_positions,
             atom_types,
             rotated_basis_vectors,
+            lattice_parameters,  # TODO rotate those as well
             times,
             noises,
             forces,
@@ -326,6 +342,7 @@ class BaseTestScoreEquivariance(BaseTestScoreNetwork):
         cartesian_positions,
         atom_types,
         basis_vectors,
+        lattice_parameters,
         times,
         noises,
         forces,
@@ -357,6 +374,7 @@ class BaseTestScoreEquivariance(BaseTestScoreNetwork):
             new_cartesian_positions,
             new_atom_types,
             basis_vectors,
+            lattice_parameters,
             times,
             noises,
             forces,
@@ -388,7 +406,7 @@ class BaseTestScoreEquivariance(BaseTestScoreNetwork):
         rotated_basis_vectors,
         cartesian_rotations,
         rotated_scores_should_match,
-        atom_output_should_be_tested_for_rotational_equivariance
+        atom_output_should_be_tested_for_rotational_equivariance,
     ):
 
         # The score is ~ nabla_x ln P. There must a be a basis change to turn it into a cartesian score of the

--- a/tests/models/score_network/test_score_network_general_tests.py
+++ b/tests/models/score_network/test_score_network_general_tests.py
@@ -120,6 +120,13 @@ class BaseScoreNetworkGeneralTests(BaseTestScoreNetwork):
     def noises(self, batch_size):
         return torch.rand(batch_size, 1)
 
+    @pytest.fixture
+    def lattice_parameters(self, basis_vectors, spatial_dimension):
+        lattice_dim = int(spatial_dimension * (spatial_dimension + 1) / 2)
+        lattice_params = torch.zeros(basis_vectors.shape[0], lattice_dim)
+        lattice_params[:, :spatial_dimension] = torch.diagonal(basis_vectors, dim1=-2, dim2=-1)
+        return lattice_params
+
     @pytest.fixture()
     def batch(
         self,
@@ -128,16 +135,17 @@ class BaseScoreNetworkGeneralTests(BaseTestScoreNetwork):
         times,
         noises,
         basis_vectors,
+        lattice_parameters,
         atom_types,
     ):
         return {
             NOISY_AXL_COMPOSITION: AXL(
                 A=atom_types,
                 X=relative_coordinates,
-                L=torch.zeros_like(atom_types),  # TODO
+                L=lattice_parameters,
             ),
             TIME: times,
-            UNIT_CELL: basis_vectors,
+            UNIT_CELL: basis_vectors,  # TODO remove this
             NOISE: noises,
             CARTESIAN_FORCES: cartesian_forces,
         }

--- a/tests/models/test_axl_diffusion_lightning_model.py
+++ b/tests/models/test_axl_diffusion_lightning_model.py
@@ -21,9 +21,12 @@ from diffusion_for_multi_scale_molecular_dynamics.models.scheduler import (
 from diffusion_for_multi_scale_molecular_dynamics.models.score_networks.mlp_score_network import \
     MLPScoreNetworkParameters
 from diffusion_for_multi_scale_molecular_dynamics.namespace import (
-    ATOM_TYPES, AXL_COMPOSITION, CARTESIAN_FORCES, RELATIVE_COORDINATES)
+    ATOM_TYPES, AXL_COMPOSITION, CARTESIAN_FORCES, LATTICE_PARAMETERS,
+    RELATIVE_COORDINATES)
 from diffusion_for_multi_scale_molecular_dynamics.noise_schedulers.noise_parameters import \
     NoiseParameters
+from diffusion_for_multi_scale_molecular_dynamics.noisers.lattice_noiser import \
+    LatticeDataParameters
 from diffusion_for_multi_scale_molecular_dynamics.oracle.energy_oracle import (
     EnergyOracle, OracleParameters)
 from diffusion_for_multi_scale_molecular_dynamics.oracle.energy_oracle_factory import (
@@ -53,7 +56,7 @@ class FakeEnergyOracle(EnergyOracle):
         return np.random.rand()
 
 
-class FakePositionsDataModule(LightningDataModule):
+class FakeAXLDataModule(LightningDataModule):
     def __init__(
         self,
         batch_size: int = 4,
@@ -71,14 +74,15 @@ class FakePositionsDataModule(LightningDataModule):
         all_atom_types = torch.randint(
             0, num_atom_types, (dataset_size, number_of_atoms)
         )
-        box = torch.rand(spatial_dimension)
+        box = torch.rand(int(spatial_dimension * (spatial_dimension + 1) / 2))
+
         self.data = [
             {
                 RELATIVE_COORDINATES: coordinate_configuration,
                 ATOM_TYPES: atom_configuration,
-                "box": box,
+                LATTICE_PARAMETERS: box,
                 CARTESIAN_FORCES: torch.zeros_like(coordinate_configuration),
-                "potential_energy": potential_energy
+                "potential_energy": potential_energy,
             }
             for coordinate_configuration, atom_configuration, potential_energy in zip(
                 all_relative_coordinates, all_atom_types, potential_energies
@@ -165,6 +169,14 @@ class TestPositionDiffusionLightningModel:
         return spatial_dimension * [unit_cell_size]
 
     @pytest.fixture()
+    def lattice_parameters(self, unit_cell_size, spatial_dimension):
+        lattice_params = LatticeDataParameters(
+            inverse_average_density=unit_cell_size**spatial_dimension,
+            spatial_dimension=spatial_dimension,
+        )
+        return lattice_params
+
+    @pytest.fixture()
     def sampling_parameters(
         self,
         number_of_atoms,
@@ -188,7 +200,8 @@ class TestPositionDiffusionLightningModel:
         metrics_parameters = SamplingMetricsParameters(
             structure_factor_max_distance=1.0,
             compute_energies=True,
-            compute_structure_factor=False)
+            compute_structure_factor=False,
+        )
         diffusion_sampling_parameters = DiffusionSamplingParameters(
             sampling_parameters=sampling_parameters,
             noise_parameters=noise_parameters,
@@ -208,6 +221,7 @@ class TestPositionDiffusionLightningModel:
         loss_parameters,
         sampling_parameters,
         diffusion_sampling_parameters,
+        lattice_parameters,
     ):
         score_network_parameters = MLPScoreNetworkParameters(
             number_of_atoms=number_of_atoms,
@@ -222,7 +236,7 @@ class TestPositionDiffusionLightningModel:
 
         noise_parameters = NoiseParameters(total_time_steps=15)
 
-        oracle_parameters = OracleParameters(name='test', elements=unique_elements)
+        oracle_parameters = OracleParameters(name="test", elements=unique_elements)
 
         hyper_params = AXLDiffusionParameters(
             score_network_parameters=score_network_parameters,
@@ -231,7 +245,8 @@ class TestPositionDiffusionLightningModel:
             noise_parameters=noise_parameters,
             loss_parameters=loss_parameters,
             diffusion_sampling_parameters=diffusion_sampling_parameters,
-            oracle_parameters=oracle_parameters
+            oracle_parameters=oracle_parameters,
+            lattice_parameters=lattice_parameters,
         )
         return hyper_params
 
@@ -255,7 +270,7 @@ class TestPositionDiffusionLightningModel:
     def fake_datamodule(
         self, batch_size, number_of_atoms, spatial_dimension, num_atom_types
     ):
-        data_module = FakePositionsDataModule(
+        data_module = FakeAXLDataModule(
             batch_size=batch_size,
             number_of_atoms=number_of_atoms,
             spatial_dimension=spatial_dimension,

--- a/tests/noisers/test_atom_types_noiser.py
+++ b/tests/noisers/test_atom_types_noiser.py
@@ -7,7 +7,7 @@ from diffusion_for_multi_scale_molecular_dynamics.noisers.atom_types_noiser impo
 
 
 @pytest.mark.parametrize("shape", [(10, 1), (4, 5, 3), (2, 2, 2, 2)])
-class TestNoisyAtomTypesSampler:
+class TestAtomTypesNoiser:
 
     @pytest.fixture(scope="class", autouse=True)
     def set_random_seed(self):

--- a/tests/noisers/test_lattice_noiser.py
+++ b/tests/noisers/test_lattice_noiser.py
@@ -121,7 +121,7 @@ class TestLatticeNoiser:
         ):
             density = natom ** (1 / spatial_dimension) / inverse_average_density
             sample_bias = np.sqrt(alpha_bar) * l0 + (1 - np.sqrt(alpha_bar)) * density
-            sample_noisy_part = epsilon * (1 - alpha_bar) * sigma**2
+            sample_noisy_part = epsilon * torch.sqrt((1 - alpha_bar) * sigma**2)
             expected_sample = sample_noisy_part + sample_bias
 
             torch.testing.assert_close(computed_sample, expected_sample)

--- a/tests/noisers/test_lattice_noiser.py
+++ b/tests/noisers/test_lattice_noiser.py
@@ -1,0 +1,127 @@
+import numpy as np
+import pytest
+import torch
+
+from diffusion_for_multi_scale_molecular_dynamics.noisers.lattice_noiser import (
+    LatticeDataParameters, LatticeNoiser)
+
+
+@pytest.mark.parametrize("spatial_dimension", [1, 2, 3])
+@pytest.mark.parametrize("inverse_average_density", [1.0, 0.7, 11.0])
+@pytest.mark.parametrize("number_of_atoms", [1, 2, 10, 20])
+class TestLatticeNoiser:
+
+    @pytest.fixture(scope="class", autouse=True)
+    def set_random_seed(self):
+        torch.manual_seed(23423)
+
+    @pytest.fixture()
+    def num_lattice_parameters(self, spatial_dimension):
+        return int(spatial_dimension * (spatial_dimension + 1) / 2)
+
+    @pytest.fixture()
+    def batch_size(self):
+        return 16
+
+    @pytest.fixture()
+    def lattice_parameters(self, spatial_dimension, inverse_average_density):
+        return LatticeDataParameters(
+            inverse_average_density=inverse_average_density,
+            spatial_dimension=spatial_dimension,
+        )
+
+    @pytest.fixture()
+    def lattice_noiser(self, lattice_parameters):
+        return LatticeNoiser(lattice_parameters)
+
+    @pytest.fixture()
+    def real_lattice_parameters(self, batch_size, num_lattice_parameters):
+        return torch.rand(batch_size, num_lattice_parameters)
+
+    @pytest.fixture()
+    def sigmas(self, batch_size, num_lattice_parameters):
+        return torch.rand(batch_size, num_lattice_parameters)
+
+    @pytest.fixture()
+    def alpha_bars(self, batch_size, num_lattice_parameters):
+        return torch.rand(batch_size, num_lattice_parameters)
+
+    @pytest.fixture()
+    def num_atoms_tensor(self, batch_size, num_lattice_parameters, number_of_atoms):
+        return torch.ones(batch_size, num_lattice_parameters) * number_of_atoms
+
+    @pytest.fixture()
+    def computed_noisy_lattice_parameters(
+        self,
+        lattice_noiser,
+        real_lattice_parameters,
+        sigmas,
+        alpha_bars,
+        num_atoms_tensor,
+    ):
+        return lattice_noiser.get_noisy_lattice_vectors(
+            real_lattice_parameters, sigmas, alpha_bars, num_atoms_tensor
+        )
+
+    @pytest.fixture()
+    def fake_gaussian_sample(self, batch_size, num_lattice_parameters):
+        # Note: this is NOT a Gaussian distribution. That's ok, it's fake data for testing!
+        return torch.rand(batch_size, num_lattice_parameters)
+
+    def test_shape(
+        self, computed_noisy_lattice_parameters, batch_size, num_lattice_parameters
+    ):
+        assert computed_noisy_lattice_parameters.shape == (
+            batch_size,
+            num_lattice_parameters,
+        )
+
+    def test_get_noisy_lattice_parameters_sample(
+        self,
+        mocker,
+        real_lattice_parameters,
+        sigmas,
+        alpha_bars,
+        fake_gaussian_sample,
+        lattice_noiser,
+        num_atoms_tensor,
+        spatial_dimension,
+        inverse_average_density,
+    ):
+        mocker.patch.object(
+            lattice_noiser,
+            "_get_gaussian_noise",
+            return_value=fake_gaussian_sample,
+        )
+
+        computed_samples = lattice_noiser.get_noisy_lattice_vectors(
+            real_lattice_parameters,
+            sigmas,
+            alpha_bars,
+            num_atoms_tensor,
+        )
+
+        flat_sigmas = sigmas.flatten()
+        flat_alphas = alpha_bars.flatten()
+        num_atoms_tensor[:, spatial_dimension:] = (
+            0  # used to remove the bias component for the angles
+        )
+        flat_num_atoms = num_atoms_tensor.flatten()
+        flat_lattice_parameters = real_lattice_parameters.flatten()
+        flat_computed_samples = computed_samples.flatten()
+        flat_fake_gaussian_sample = fake_gaussian_sample.flatten()
+
+        for sigma, alpha_bar, natom, l0, computed_sample, epsilon in zip(
+            flat_sigmas,
+            flat_alphas,
+            flat_num_atoms,
+            flat_lattice_parameters,
+            flat_computed_samples,
+            flat_fake_gaussian_sample,
+        ):
+            density = natom ** (1 / spatial_dimension) / inverse_average_density
+            sample_bias = np.sqrt(alpha_bar) * l0 + (1 - np.sqrt(alpha_bar)) * density
+            sample_noisy_part = epsilon * (1 - alpha_bar) * sigma**2
+            expected_sample = sample_noisy_part + sample_bias
+
+            torch.testing.assert_close(computed_sample, expected_sample)

--- a/tests/noisers/test_relative_coordinates_noiser.py
+++ b/tests/noisers/test_relative_coordinates_noiser.py
@@ -7,7 +7,7 @@ from diffusion_for_multi_scale_molecular_dynamics.noisers.relative_coordinates_n
 
 
 @pytest.mark.parametrize("shape", [(10, 1), (4, 5, 3), (2, 2, 2, 2)])
-class TestNoisyRelativeCoordinatesSampler:
+class TestRelativeCoordinatesNoiser:
 
     @pytest.fixture(scope="class", autouse=True)
     def set_random_seed(self):

--- a/tests/score/test_gaussian_score.py
+++ b/tests/score/test_gaussian_score.py
@@ -1,0 +1,74 @@
+import numpy as np
+import pytest
+import torch
+
+from diffusion_for_multi_scale_molecular_dynamics.score.gaussian_score import \
+    get_lattice_sigma_normalized_score
+
+
+@pytest.fixture(scope="module", autouse=True)
+def set_random_seed():
+    torch.manual_seed(1234)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def set_default_type_to_float64():
+    torch.set_default_dtype(torch.float64)
+    yield
+    # this returns the default type to float32 at the end of all tests in this class in order
+    # to not affect other tests.
+    torch.set_default_dtype(torch.float32)
+
+
+@pytest.fixture
+def num_lattice_parameters(spatial_dimension):
+    return int(spatial_dimension * (spatial_dimension + 1) / 2)
+
+
+@pytest.fixture
+def lattice_parameters(batch_size, num_lattice_parameters):
+    # input to score is lt - l0 so values can be negative
+    return torch.randn(batch_size, num_lattice_parameters)
+
+
+@pytest.fixture
+def sigmas(batch_size, num_lattice_parameters):
+    return torch.rand(batch_size, num_lattice_parameters) * 0.01
+
+
+@pytest.fixture
+def alpha_bars(batch_size, num_lattice_parameters):
+    return torch.rand(batch_size, num_lattice_parameters)
+
+
+@pytest.fixture
+def expected_sigma_normalized_scores(lattice_parameters, sigmas, alpha_bars):
+    shape = lattice_parameters.shape
+
+    list_sigma_normalized_scores = []
+    for dl, sigma, alpha_bar in zip(
+        lattice_parameters.numpy().flatten(),
+        sigmas.numpy().flatten(),
+        alpha_bars.flatten(),
+    ):
+        s = -dl / (np.sqrt(1 - alpha_bar) * sigma)
+        list_sigma_normalized_scores.append(s)
+
+    return torch.tensor(list_sigma_normalized_scores).reshape(shape)
+
+
+@pytest.mark.parametrize("batch_size", [1, 3, 7, 16])
+@pytest.mark.parametrize("spatial_dimension", [1, 2, 3])
+def test_get_sigma_normalized_score(
+    lattice_parameters, sigmas, alpha_bars, expected_sigma_normalized_scores
+):
+    sigma_normalized_score = get_lattice_sigma_normalized_score(
+        lattice_parameters,
+        sigmas,
+        alpha_bars,
+    )
+
+    torch.testing.assert_close(
+        sigma_normalized_score,
+        expected_sigma_normalized_scores,
+    )

--- a/tests/score/test_wrapped_gaussian_score.py
+++ b/tests/score/test_wrapped_gaussian_score.py
@@ -7,7 +7,8 @@ from diffusion_for_multi_scale_molecular_dynamics.score.wrapped_gaussian_score i
     _get_s1b_exponential, _get_sigma_normalized_s2,
     _get_sigma_square_times_score_1_from_exponential,
     _get_small_sigma_large_u_mask, _get_small_sigma_small_u_mask,
-    get_coordinates_sigma_normalized_score, get_sigma_normalized_score_brute_force)
+    get_coordinates_sigma_normalized_score,
+    get_sigma_normalized_score_brute_force)
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/score/test_wrapped_gaussian_score.py
+++ b/tests/score/test_wrapped_gaussian_score.py
@@ -7,7 +7,7 @@ from diffusion_for_multi_scale_molecular_dynamics.score.wrapped_gaussian_score i
     _get_s1b_exponential, _get_sigma_normalized_s2,
     _get_sigma_square_times_score_1_from_exponential,
     _get_small_sigma_large_u_mask, _get_small_sigma_small_u_mask,
-    get_sigma_normalized_score, get_sigma_normalized_score_brute_force)
+    get_coordinates_sigma_normalized_score, get_sigma_normalized_score_brute_force)
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -196,7 +196,7 @@ def test_get_sigma_normalized_s2(list_u, list_sigma, list_k, numerical_type):
 def test_get_sigma_normalized_score(
     relative_coordinates, sigmas, kmax, expected_sigma_normalized_scores
 ):
-    sigma_normalized_score_small_sigma = get_sigma_normalized_score(
+    sigma_normalized_score_small_sigma = get_coordinates_sigma_normalized_score(
         relative_coordinates, sigmas, kmax
     )
 

--- a/tests/test_train_diffusion.py
+++ b/tests/test_train_diffusion.py
@@ -161,6 +161,7 @@ def get_config(
         seed=9999,
         spatial_dimension=3,
         elements=unique_elements,
+        cell_dimensions=[10., 10., 10.],
         data=data_config,
         model=model_config,
         optimizer=optimizer_config,

--- a/tests/utils/test_noise_utils.py
+++ b/tests/utils/test_noise_utils.py
@@ -1,0 +1,36 @@
+import numpy as np
+import pytest
+import torch
+
+from diffusion_for_multi_scale_molecular_dynamics.utils.noise_utils import \
+    scale_sigma_by_number_of_atoms
+
+
+@pytest.fixture
+def number_of_atoms(batch_size):
+    return torch.randint(0, 100, (batch_size,))
+
+
+@pytest.fixture
+def sigma(batch_size):
+    return torch.rand(batch_size)
+
+
+@pytest.fixture
+def expected_scaled_sigma(sigma, number_of_atoms, spatial_dimension):
+    scaled_sigma = []
+    for s, n in zip(sigma, number_of_atoms):
+        scaled_s = s / np.power(n, 1 / spatial_dimension)
+        scaled_sigma.append(scaled_s)
+    return torch.tensor(scaled_sigma)
+
+
+@pytest.mark.parametrize("batch_size", [4, 8])
+@pytest.mark.parametrize("spatial_dimension", [1, 2, 3])
+def test_scale_sigma_by_number_of_atoms(
+    spatial_dimension, number_of_atoms, sigma, expected_scaled_sigma
+):
+    computed_scaled_sigma = scale_sigma_by_number_of_atoms(
+        sigma, number_of_atoms, spatial_dimension
+    )
+    torch.testing.assert_allclose(expected_scaled_sigma, computed_scaled_sigma)


### PR DESCRIPTION
In this initial PR, I implemented a loss function for the lattice parameters and connected the AXL diffusion model. The scripts for a minimal experiment are in place - up to the generation & evaluation process.
Many tests are failing because they invoke a generator step. This does not work here, but should be fixed in a future PR. 
I added a head to the MLP module so we can get a full training step in the base AXL diffusion model. This is meant for development, it might not be the final implementation.
I followed MatterGen recommendations wrt to scaling sigma by the number of atoms for the lattice. I did not implement the changes for the relative coordinates. The tools are in place though and could easily be done in a future PR.

For the lattice parameters, I am assuming there are spatial dimension x (1 + spatial dimension) / 2 values. The first spatial dimension values matches the length of the lattice vectors, the rest are angles (or other variables with similar semantic value). 