### PR TITLE
Architecture inductive bias

### DIFF
--- a/experiments/dataset_analysis/dataset_covariance.py
+++ b/experiments/dataset_analysis/dataset_covariance.py
@@ -21,8 +21,8 @@ from diffusion_for_multi_scale_molecular_dynamics.utils.logging_utils import \
     setup_analysis_logger
 
 logger = logging.getLogger(__name__)
-dataset_name = "si_diffusion_2x2x2"
-# dataset_name = 'si_diffusion_1x1x1'
+# dataset_name = "si_diffusion_2x2x2"
+dataset_name = 'si_diffusion_1x1x1'
 
 output_dir = ANALYSIS_RESULTS_DIR / "covariances"
 output_dir.mkdir(exist_ok=True)
@@ -40,7 +40,7 @@ processed_dataset_dir = lammps_run_dir / "processed"
 
 cache_dir = lammps_run_dir / "cache"
 
-data_params = LammpsDataModuleParameters(batch_size=2048, max_atom=max_atom)
+data_params = LammpsDataModuleParameters(batch_size=2048, max_atom=max_atom, elements=['Si'])
 
 if __name__ == "__main__":
     setup_analysis_logger()

--- a/experiments/regularization_toy_problem/visualize_score_vector_field_2D.py
+++ b/experiments/regularization_toy_problem/visualize_score_vector_field_2D.py
@@ -19,6 +19,7 @@ plt.style.use(PLOT_STYLE_PATH)
 
 
 output_file_path = RESULTS_DIR / "mlp_score_no_regularizer.mp4"
+checkpoint_path = glob.glob(str(EXPERIMENTS_DIR / "no_regularizer/**/last_model*.ckpt"), recursive=True)[0]
 
 sigma_min = 0.001
 sigma_max = 0.2
@@ -29,11 +30,6 @@ x0_1 = 0.25
 x0_2 = 0.75
 
 if __name__ == "__main__":
-
-    checkpoint_path = glob.glob(
-        str(EXPERIMENTS_DIR / "no_regularizer/**/last_model*.ckpt"), recursive=True
-    )[0]
-
     checkpoint_name = Path(checkpoint_path).name
     axl_network = get_axl_network(checkpoint_path)
 

--- a/src/diffusion_for_multi_scale_molecular_dynamics/analysis/score_viewer.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/analysis/score_viewer.py
@@ -22,7 +22,6 @@ from diffusion_for_multi_scale_molecular_dynamics.utils.basis_transformations im
     map_relative_coordinates_to_unit_cell
 from diffusion_for_multi_scale_molecular_dynamics.utils.structure_utils import \
     get_orthogonal_basis_vectors
-from experiments.analysis.analytic_score.utils import get_silicon_supercell
 
 plt.style.use(PLOT_STYLE_PATH)
 
@@ -336,9 +335,17 @@ if __name__ == "__main__":
 
     cell_dimensions = [5.43, 5.43, 5.43]
 
-    equilibrium = get_silicon_supercell(supercell_factor=1)
-    start = equilibrium.copy()
-    end = equilibrium.copy()
+    equilibrium = torch.tensor([[0.5, 0., 0.],
+                                [0.25, 0.25, 0.75],
+                                [0.5, 0.5, 0.5],
+                                [0.25, 0.75, 0.25],
+                                [0., 0., 0.5],
+                                [0.75, 0.25, 0.25],
+                                [0., 0.5, 0.],
+                                [0.75, 0.75, 0.75]])
+
+    start = equilibrium.clone()
+    end = equilibrium.clone()
     end[1] = equilibrium[0]
     end[0] = equilibrium[1]
 

--- a/src/diffusion_for_multi_scale_molecular_dynamics/analysis/score_viewer.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/analysis/score_viewer.py
@@ -30,6 +30,7 @@ class ScoreViewerParameters:
 
     sigma_min: float
     sigma_max: float
+    schedule_type: str
 
     number_of_space_steps: int = 100
 
@@ -60,6 +61,7 @@ class ScoreViewer:
             total_time_steps=total_time_steps,
             sigma_min=score_viewer_parameters.sigma_min,
             sigma_max=score_viewer_parameters.sigma_max,
+            schedule_type=score_viewer_parameters.schedule_type
         )
 
         self.times = torch.tensor([0.0, 0.1, 0.2, 0.3, 0.4, 0.8, 0.9, 1.0])

--- a/src/diffusion_for_multi_scale_molecular_dynamics/analysis/score_viewer.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/analysis/score_viewer.py
@@ -336,6 +336,7 @@ if __name__ == "__main__":
     score_viewer_parameters = ScoreViewerParameters(
         sigma_min=0.001,
         sigma_max=0.2,
+        schedule_type='linear',
         starting_relative_coordinates=[[0.0], [1.0]],
         ending_relative_coordinates=[[1.0], [0.0]],
     )

--- a/src/diffusion_for_multi_scale_molecular_dynamics/callbacks/score_viewer_callback.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/callbacks/score_viewer_callback.py
@@ -62,7 +62,7 @@ class ScoreViewerCallback(Callback):
         if not self._compute_results_at_this_epoch(trainer.current_epoch):
             return
 
-        figure = self.score_viewer.create_figure(score_network=pl_model.axl_network)
+        figure = self.score_viewer.create_figure(score_network=pl_model.axl_network, device=pl_model.device)
         figure.suptitle(f"Epoch {trainer.current_epoch}, Step {trainer.global_step}")
         # Set the DPI so we can actually see something in the logger window.
         figure.set_dpi(100)

--- a/src/diffusion_for_multi_scale_molecular_dynamics/noise_schedulers/noise_parameters.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/noise_schedulers/noise_parameters.py
@@ -4,8 +4,11 @@ from dataclasses import dataclass
 @dataclass
 class NoiseParameters:
     """Noise schedule parameters."""
-
     total_time_steps: int
+
+    # the kind of schedule that is created
+    schedule_type: str = "exponential"
+
     time_delta: float = 1e-5  # the time schedule will cover the range [time_delta, 1]
     # As discussed in Appendix C of "SCORE-BASED GENERATIVE MODELING THROUGH STOCHASTIC DIFFERENTIAL EQUATIONS",
     # the time t = 0 is problematic.
@@ -26,3 +29,8 @@ class NoiseParameters:
     # https: // github.com / yang - song / score_sde / blob / main / configs / default_celeba_configs.py
     # for the celeba dataset. Note the suggested value for CIFAR10 is 0.16 in that repo.
     corrector_r: float = 0.17
+
+    def __post_init__(self):
+        """Check parameters."""
+        assert self.schedule_type in ["exponential", "linear"], (
+            f"The schedule type {self.schedule_type} is not supported.")

--- a/src/diffusion_for_multi_scale_molecular_dynamics/noise_schedulers/sigma_calculator.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/noise_schedulers/sigma_calculator.py
@@ -2,6 +2,17 @@ import torch
 from torch import nn
 
 
+def instantiate_sigma_calculator(sigma_min: float, sigma_max: float, schedule_type: str):
+    """Instantiate a sigma calculator bvased on the schedule type."""
+    match schedule_type:
+        case "exponential":
+            return ExponentialSigmaCalculator(sigma_min, sigma_max)
+        case "linear":
+            return LinearSigmaCalculator(sigma_min, sigma_max)
+        case _:
+            raise NotImplementedError(f"The schedule type {schedule_type} is not implemented")
+
+
 class SigmaCalculator(nn.Module):
     """Sigma Calculator Base Class."""
 

--- a/src/diffusion_for_multi_scale_molecular_dynamics/noise_schedulers/sigma_calculator.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/noise_schedulers/sigma_calculator.py
@@ -1,0 +1,97 @@
+import torch
+from torch import nn
+
+
+class SigmaCalculator(nn.Module):
+    """Sigma Calculator Base Class."""
+
+    def __init__(self, sigma_min: float, sigma_max: float):
+        """Init method.
+
+        Args:
+            sigma_min: minimum value of sigma
+            sigma_max: maximum value of sigma
+        """
+        super().__init__()
+
+        self.sigma_min = torch.nn.Parameter(
+            torch.tensor(sigma_min), requires_grad=False
+        )
+        self.sigma_max = torch.nn.Parameter(
+            torch.tensor(sigma_max), requires_grad=False
+        )
+
+    def get_sigma(self, times: torch.Tensor) -> torch.Tensor:
+        """Get sigma."""
+        raise NotImplementedError("This method must be implemented in a child class.")
+
+    def get_sigma_time_derivative(self, times: torch.Tensor) -> torch.Tensor:
+        """Get sigma time derivative."""
+        raise NotImplementedError("This method must be implemented in a child class.")
+
+    def forward(self, times: torch.Tensor) -> torch.Tensor:
+        """Forward method."""
+        return self.get_sigma(times)
+
+
+class ExponentialSigmaCalculator(SigmaCalculator):
+    """Exponential Sigma Calculator.
+
+    The schedule is given by
+
+        sigma(t) = sigma_min * (sigma_max / sigma_min)^t
+
+    """
+
+    def __init__(self, sigma_min: float, sigma_max: float):
+        """Init method.
+
+        Args:
+            sigma_min: minimum value of sigma
+            sigma_max: maximum value of sigma
+        """
+        super().__init__(sigma_min, sigma_max)
+        self.ratio = torch.nn.Parameter(
+            self.sigma_max / self.sigma_min, requires_grad=False
+        )
+        self.log_ratio = torch.nn.Parameter(
+            torch.log(self.sigma_max / self.sigma_min), requires_grad=False
+        )
+
+    def get_sigma(self, times: torch.Tensor) -> torch.Tensor:
+        """Get sigma."""
+        return self.sigma_min * self.ratio**times
+
+    def get_sigma_time_derivative(self, times: torch.Tensor) -> torch.Tensor:
+        """Get sigma time derivative."""
+        return self.log_ratio * self.get_sigma(times)
+
+
+class LinearSigmaCalculator(SigmaCalculator):
+    """Linear Sigma Calculator.
+
+    The schedule is given by
+
+        sigma(t) = sigma_min + (sigma_max - sigma_min) * t
+
+    """
+
+    def __init__(self, sigma_min: float, sigma_max: float):
+        """Init method.
+
+        Args:
+            sigma_min: minimum value of sigma
+            sigma_max: maximum value of sigma
+        """
+        super().__init__(sigma_min, sigma_max)
+        self.sigma_difference = torch.nn.Parameter(
+            self.sigma_max - self.sigma_min, requires_grad=False
+        )
+
+    def get_sigma(self, times: torch.Tensor) -> torch.Tensor:
+        """Get sigma."""
+        return self.sigma_min + self.sigma_difference * times
+
+    def get_sigma_time_derivative(self, times: torch.Tensor) -> torch.Tensor:
+        """Get sigma time derivative."""
+        return self.sigma_difference * torch.ones_like(times)

--- a/src/diffusion_for_multi_scale_molecular_dynamics/regularizers/fokker_planck_regularizer.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/regularizers/fokker_planck_regularizer.py
@@ -8,8 +8,8 @@ from diffusion_for_multi_scale_molecular_dynamics.models.score_networks import \
     ScoreNetwork
 from diffusion_for_multi_scale_molecular_dynamics.namespace import (
     AXL, CARTESIAN_FORCES, NOISE, NOISY_AXL_COMPOSITION, TIME, UNIT_CELL)
-from diffusion_for_multi_scale_molecular_dynamics.noise_schedulers.exploding_variance import \
-    SigmaCalculator
+from diffusion_for_multi_scale_molecular_dynamics.noise_schedulers.sigma_calculator import \
+    instantiate_sigma_calculator
 from diffusion_for_multi_scale_molecular_dynamics.regularizers.regularizer import (
     Regularizer, RegularizerParameters)
 
@@ -30,6 +30,7 @@ class FokkerPlanckRegularizerParameters(RegularizerParameters):
     # Define the noise schedule. Should be consistent with the score parameters.
     sigma_min: float
     sigma_max: float
+    schedule_type: str = "exponential"
 
     def __post_init__(self):
         """Verify conditions in post init."""
@@ -54,10 +55,9 @@ class FokkerPlanckRegularizer(Regularizer):
     def __init__(self, regularizer_parameters: FokkerPlanckRegularizerParameters):
         """Init method."""
         super().__init__(regularizer_parameters)
-        self.sigma_calculator = SigmaCalculator(
-            sigma_min=regularizer_parameters.sigma_min,
-            sigma_max=regularizer_parameters.sigma_max,
-        )
+        self.sigma_calculator = instantiate_sigma_calculator(regularizer_parameters.sigma_min,
+                                                             regularizer_parameters.sigma_max,
+                                                             regularizer_parameters.schedule_type)
 
         self.use_hte_approximation = regularizer_parameters.use_hte_approximation
         self.number_of_hte_terms = regularizer_parameters.number_of_hte_terms

--- a/tests/models/score_network/test_score_network_equivariance.py
+++ b/tests/models/score_network/test_score_network_equivariance.py
@@ -513,11 +513,15 @@ class TestEquivarianceMaceWithEquivariantScorePredictionHead(BaseTestScoreEquiva
 
 class TestEquivarianceEGNN(BaseTestScoreEquivariance):
 
+    @pytest.fixture(params=[True, False])
+    def normalize(self, request):
+        return request.param
+
     @pytest.fixture(params=[("fully_connected", None), ("radial_cutoff", 3.0)])
-    def score_network_parameters(self, request, num_atom_types):
+    def score_network_parameters(self, request, num_atom_types, normalize):
         edges, radial_cutoff = request.param
         return EGNNScoreNetworkParameters(
-            edges=edges, radial_cutoff=radial_cutoff, num_atom_types=num_atom_types
+            edges=edges, radial_cutoff=radial_cutoff, num_atom_types=num_atom_types, normalize=normalize
         )
 
     @pytest.fixture()

--- a/tests/models/score_network/test_score_network_general_tests.py
+++ b/tests/models/score_network/test_score_network_general_tests.py
@@ -199,6 +199,7 @@ class BaseScoreNetworkGeneralTests(BaseTestScoreNetwork):
 @pytest.mark.parametrize("n_hidden_dimensions", [1, 2, 3])
 @pytest.mark.parametrize("hidden_dimensions_size", [8, 16])
 @pytest.mark.parametrize("embedding_dimensions_size", [4, 12])
+@pytest.mark.parametrize("use_time_dependent_prefactor", [True, False])
 class TestMLPScoreNetwork(BaseScoreNetworkGeneralTests):
 
     @pytest.fixture()
@@ -210,6 +211,7 @@ class TestMLPScoreNetwork(BaseScoreNetworkGeneralTests):
         embedding_dimensions_size,
         n_hidden_dimensions,
         hidden_dimensions_size,
+        use_time_dependent_prefactor
     ):
         return MLPScoreNetworkParameters(
             spatial_dimension=spatial_dimension,
@@ -221,6 +223,7 @@ class TestMLPScoreNetwork(BaseScoreNetworkGeneralTests):
             atom_type_embedding_dimensions_size=embedding_dimensions_size,
             n_hidden_dimensions=n_hidden_dimensions,
             hidden_dimensions_size=hidden_dimensions_size,
+            use_time_dependent_prefactor=use_time_dependent_prefactor
         )
 
     @pytest.fixture()

--- a/tests/models/test_egcl.py
+++ b/tests/models/test_egcl.py
@@ -57,3 +57,15 @@ class TestEGCL:
         torch.testing.assert_close(
             computed_displacement, simple_pair_coord[1, :].unsqueeze(0)
         )
+
+    def test_normalize_distance(self, egcl):
+
+        zero = torch.tensor(0.)
+        one = torch.tensor(1.)
+        large = torch.tensor(1.0e3)
+
+        torch.testing.assert_close(egcl.normalize_radial_norm(zero), zero)
+
+        large_distance_norm = large * egcl.normalize_radial_norm(large**2)
+
+        torch.testing.assert_close(large_distance_norm, one)

--- a/tests/noise_schedulers/test_sigma_calculator.py
+++ b/tests/noise_schedulers/test_sigma_calculator.py
@@ -1,0 +1,78 @@
+import numpy as np
+import pytest
+import torch
+
+from diffusion_for_multi_scale_molecular_dynamics.noise_schedulers.sigma_calculator import (
+    ExponentialSigmaCalculator, LinearSigmaCalculator)
+
+
+class TestExplodingVariance:
+
+    @pytest.fixture(scope="class", autouse=True)
+    def set_random_seed(self):
+        torch.manual_seed(23423)
+
+    @pytest.fixture()
+    def sigma_min(self):
+        return 0.001
+
+    @pytest.fixture()
+    def sigma_max(self):
+        return 0.5
+
+    @pytest.fixture()
+    def times(self):
+        return torch.rand(100)
+
+    @pytest.fixture(params=["exponential", "linear"])
+    def schedule_type(self, request):
+        return request.param
+
+    @pytest.fixture()
+    def expected_exponential(self, sigma_min, sigma_max, times):
+        expected_sigmas = []
+        expected_sigmas_time_derivatives = []
+        ratio = np.log(sigma_max / sigma_min)
+        for t in times:
+            sigma = sigma_min ** (1.0 - t) * sigma_max**t
+            expected_sigmas.append(sigma)
+
+            d_sigma_dt = sigma * ratio
+            expected_sigmas_time_derivatives.append(d_sigma_dt)
+
+        return torch.tensor(expected_sigmas), torch.tensor(expected_sigmas_time_derivatives)
+
+    @pytest.fixture()
+    def expected_linear(self, sigma_min, sigma_max, times):
+        expected_sigmas = []
+        expected_sigmas_time_derivatives = []
+        for t in times:
+            sigma = sigma_min + (sigma_max - sigma_min) * t
+            expected_sigmas.append(sigma)
+            expected_sigmas_time_derivatives.append(sigma_max - sigma_min)
+
+        return torch.tensor(expected_sigmas), torch.tensor(expected_sigmas_time_derivatives)
+
+    @pytest.fixture()
+    def expected_values(self, schedule_type, expected_exponential, expected_linear):
+        if schedule_type == "exponential":
+            return expected_exponential
+        elif schedule_type == "linear":
+            return expected_linear
+        else:
+            raise NotImplementedError
+
+    @pytest.fixture()
+    def sigma_calculator(self, schedule_type, sigma_min, sigma_max):
+        if schedule_type == "exponential":
+            return ExponentialSigmaCalculator(sigma_min, sigma_max)
+        elif schedule_type == "linear":
+            return LinearSigmaCalculator(sigma_min, sigma_max)
+        else:
+            raise NotImplementedError("Unknown schedule_type")
+
+    def test_sigma_calculator(self, sigma_calculator, times, expected_values):
+        expected_sigmas, expected_sigma_time_derivatives = expected_values
+
+        torch.testing.assert_close(expected_sigmas, sigma_calculator.get_sigma(times))
+        torch.testing.assert_close(expected_sigma_time_derivatives, sigma_calculator.get_sigma_time_derivative(times))

--- a/tests/regularizers/conftest.py
+++ b/tests/regularizers/conftest.py
@@ -3,8 +3,8 @@ import torch
 
 from diffusion_for_multi_scale_molecular_dynamics.namespace import (
     AXL, CARTESIAN_FORCES, NOISE, NOISY_AXL_COMPOSITION, TIME, UNIT_CELL)
-from diffusion_for_multi_scale_molecular_dynamics.noise_schedulers.exploding_variance import \
-    SigmaCalculator
+from diffusion_for_multi_scale_molecular_dynamics.noise_schedulers.sigma_calculator import \
+    ExponentialSigmaCalculator
 from tests.regularizers.differentiable_score_network import (
     DifferentiableScoreNetwork, DifferentiableScoreNetworkParameters)
 
@@ -50,7 +50,7 @@ class BaseTestRegularizer:
 
     @pytest.fixture()
     def sigmas(self, sigma_min, sigma_max, times):
-        return SigmaCalculator(sigma_min=sigma_min, sigma_max=sigma_max).get_sigma(
+        return ExponentialSigmaCalculator(sigma_min=sigma_min, sigma_max=sigma_max).get_sigma(
             times
         )
 

--- a/tests/regularizers/differentiable_score_network.py
+++ b/tests/regularizers/differentiable_score_network.py
@@ -9,8 +9,8 @@ from diffusion_for_multi_scale_molecular_dynamics.models.score_networks import (
     ScoreNetwork, ScoreNetworkParameters)
 from diffusion_for_multi_scale_molecular_dynamics.namespace import (
     AXL, CARTESIAN_FORCES, NOISE, NOISY_AXL_COMPOSITION, TIME, UNIT_CELL)
-from diffusion_for_multi_scale_molecular_dynamics.noise_schedulers.exploding_variance import \
-    SigmaCalculator
+from diffusion_for_multi_scale_molecular_dynamics.noise_schedulers.sigma_calculator import \
+    ExponentialSigmaCalculator
 
 
 @dataclass(kw_only=True)
@@ -32,7 +32,7 @@ class DifferentiableScoreNetwork(ScoreNetwork):
     def __init__(self, hyper_params: DifferentiableScoreNetworkParameters):
         super().__init__(hyper_params)
 
-        self.sigma_calculator = SigmaCalculator(
+        self.sigma_calculator = ExponentialSigmaCalculator(
             sigma_min=hyper_params.sigma_min, sigma_max=hyper_params.sigma_max
         )
 
@@ -225,7 +225,7 @@ class TestDifferentiableScoreNetwork:
             batch_size, 1, 1
         )
 
-        sigmas_t = SigmaCalculator(sigma_min=sigma_min, sigma_max=sigma_max).get_sigma(
+        sigmas_t = ExponentialSigmaCalculator(sigma_min=sigma_min, sigma_max=sigma_max).get_sigma(
             times
         )
 


### PR DESCRIPTION
In this PR, I
- modify the behavior of EGNN when `normalize=True` to try to avoid discontinuous jumps in the score.
- I add an optional time dependent prefactor in the MLP architecture
- I create a configurable `sigma(t)` schedule. The options are now `exponential` (what we have used so far) and `linear`. 