### PR TITLE
More k shells

### DIFF
--- a/src/diffusion_for_multi_scale_molecular_dynamics/utils/lattice_utils.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/utils/lattice_utils.py
@@ -1,6 +1,10 @@
 import itertools
+from typing import List
 
 import torch
+
+from diffusion_for_multi_scale_molecular_dynamics.utils.geometric_utils import \
+    get_cubic_point_group_symmetries
 
 
 def get_relative_coordinates_lattice_vectors(
@@ -23,3 +27,151 @@ def get_relative_coordinates_lattice_vectors(
     )
 
     return list_relative_lattice_vectors
+
+
+def _sort_complete_shell(complete_shell: torch.Tensor) -> torch.Tensor:
+    """Sort complete shell.
+
+    Sort the lattice vectors so that the most positive elements appear first.
+
+    Args:
+        complete_shell: a tensor of dimension [number of lattice vectors, spatial dimension].
+
+    Returns:
+        sorted shell: the complete shell, sorted.
+    """
+    number_of_lattice_vectors, spatial_dimension = complete_shell.shape
+
+    # Build a scalar quantity that will sort following the desired rules
+    ordering_scalar = torch.zeros(number_of_lattice_vectors)
+
+    for d in range(spatial_dimension):
+        column = complete_shell[:, d]
+
+        power = spatial_dimension - d - 1
+        factor = number_of_lattice_vectors**power
+
+        sorted_unique_values = column.unique().sort().values
+
+        for rank, unique_value in enumerate(sorted_unique_values):
+            idx = column == unique_value
+            ordering_scalar[idx] += rank * factor
+
+    order = torch.flip(ordering_scalar.argsort(), dims=(0,))
+
+    ordered_shell = complete_shell[order]
+    return ordered_shell
+
+
+def get_cubic_point_group_complete_lattice_shells(
+    number_of_complete_shells: int, spatial_dimension: int = 3
+) -> List[torch.Tensor]:
+    """Get cubic point group complete lattice shells.
+
+    This method creates lattice vectors organized in fully symmetric shells, sorted according to the
+    length of a shell member, excluding L=0. If there are length degeneracies, all degenerate shells are included.
+
+    The cubic point group is ASSUMED. This should be modified to deal with other point groups.
+
+    Args:
+        number_of_complete_shells: number of complete shells of lattice vectors to create.
+        spatial_dimension: the dimension of space.
+
+    Returns:
+        list_complete_shells: a list of complete, sorted lattice vector shells.
+    """
+    number_of_trial_shells = 2 * number_of_complete_shells
+    lattice_vectors = get_relative_coordinates_lattice_vectors(
+        number_of_trial_shells, spatial_dimension
+    )
+    # sort by their norm
+    squared_norms = (lattice_vectors**2).sum(-1)
+
+    # The vectors should be composed of integers
+    sorted_lattice_vectors = lattice_vectors[squared_norms.argsort()].int()
+
+    symmetries = get_cubic_point_group_symmetries(spatial_dimension).int()
+
+    number_of_created_shells = 0
+    known_set = set()
+
+    list_complete_shells = []
+
+    previous_shell_squared_norm = 0
+
+    # Exclude zero.
+    for lattice_vector in sorted_lattice_vectors[1:]:
+        if tuple(lattice_vector.numpy()) in known_set:
+            continue
+
+        new_shell_set = set(
+            tuple(ell) for ell in torch.matmul(symmetries, lattice_vector).numpy()
+        )
+        known_set.update(new_shell_set)
+        number_of_created_shells += 1
+
+        complete_shell = _sort_complete_shell(torch.tensor(list(new_shell_set)))
+
+        list_complete_shells.append(complete_shell)
+
+        shell_squared_norm = (lattice_vector**2).sum()
+
+        if (
+            len(list_complete_shells) >= number_of_complete_shells
+            and shell_squared_norm > previous_shell_squared_norm
+        ):
+            break
+        previous_shell_squared_norm = shell_squared_norm
+
+    return list_complete_shells
+
+
+def get_cubic_point_group_positive_normalized_bloch_wave_vectors(
+    number_of_complete_shells: int, spatial_dimension: int = 3
+) -> torch.Tensor:
+    """Get cubic point group positive normalized bloch wave vectors.
+
+    This method generates reciprocal lattice vectors for the cubic lattice. The vectors are "normalized" in
+    the sense that they are made up of integers, such that, for spatial_dimension = 3,
+
+        K[m] = m_1 b_1 + m_2 b_2 + m_3 b_3,  b_i = 2pi/a e_i
+
+    The "normalized" vectors are of the form [m_1, m_2,  m_3].
+
+    We assume that inversion is part of the point group. Thus, we can transform
+
+        {e^[i K r], e^[-i K r] } ->  {cos(K r), sin(K r) }
+
+    and so there is no need to manipulate complex numbers. Thus we wil only keep half of lattice vectors,
+    removing the half that is the image under inversion.
+
+    Args:
+        number_of_complete_shells: number of complete shells to consider
+        spatial_dimension: dimension of space
+
+    Returns:
+        positive_bloch_wave_vectors: half of complete shell normalized reciprocal lattice vectors.
+    """
+    list_complete_shells = get_cubic_point_group_complete_lattice_shells(
+        number_of_complete_shells, spatial_dimension
+    )
+    list_half_shells = []
+
+    inversion = -torch.eye(spatial_dimension).int()
+
+    for shell in list_complete_shells:
+        known_set = set()
+        half_shell = []
+        for lattice_vector in shell:
+            if tuple(lattice_vector.numpy()) in known_set:
+                continue
+
+            half_shell.append(lattice_vector)
+
+            inverse_lattice_vector = torch.matmul(inversion, lattice_vector)
+            s = {tuple(lattice_vector.numpy()), tuple(inverse_lattice_vector.numpy())}
+            known_set.update(s)
+        list_half_shells.append(torch.stack(half_shell))
+
+    positive_bloch_wave_vectors = torch.vstack(list_half_shells)
+    return positive_bloch_wave_vectors

--- a/src/diffusion_for_multi_scale_molecular_dynamics/utils/lattice_utils.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/utils/lattice_utils.py
@@ -1,0 +1,25 @@
+import itertools
+
+import torch
+
+
+def get_relative_coordinates_lattice_vectors(
+    number_of_shells: int = 1, spatial_dimension: int = 3
+) -> torch.Tensor:
+    """Get relative coordinates lattice vectors.
+
+    Get all the lattice vectors in relative coordinates from -number_of_shells to +number_of_shells,
+    in every spatial directions.
+
+    Args:
+        number_of_shells: number of shifts along lattice vectors in the positive direction.
+
+    Returns:
+        list_relative_lattice_vectors : all the lattice vectors in relative coordinates (ie, integers).
+    """
+    shifts = range(-number_of_shells, number_of_shells + 1)
+    list_relative_lattice_vectors = 1.0 * torch.tensor(
+        list(itertools.product(shifts, repeat=spatial_dimension))
+    )
+
+    return list_relative_lattice_vectors

--- a/src/diffusion_for_multi_scale_molecular_dynamics/utils/neighbors.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/utils/neighbors.py
@@ -5,7 +5,6 @@ for positions in the unit cell of a periodic structure. The aim is to do this
 efficiently on the GPU without CPU-GPU communications.
 """
 
-import itertools
 from collections import namedtuple
 
 import einops
@@ -15,6 +14,8 @@ from pykeops.torch import LazyTensor
 
 from diffusion_for_multi_scale_molecular_dynamics.utils.basis_transformations import \
     get_positions_from_coordinates
+from diffusion_for_multi_scale_molecular_dynamics.utils.lattice_utils import \
+    get_relative_coordinates_lattice_vectors
 
 INDEX_PADDING_VALUE = -1
 POSITION_PADDING_VALUE = np.NaN
@@ -112,7 +113,7 @@ def get_periodic_adjacency_information(
     )
 
     # The relative coordinates lattice vectors have dimensions [number of lattice vectors, spatial_dimension]
-    relative_lattice_vectors = _get_relative_coordinates_lattice_vectors(
+    relative_lattice_vectors = get_relative_coordinates_lattice_vectors(
         number_of_shells=1, spatial_dimension=spatial_dimension
     ).to(device)
     number_of_relative_lattice_vectors = len(relative_lattice_vectors)
@@ -221,28 +222,6 @@ def get_periodic_adjacency_information(
         node_batch_indices=torch.repeat_interleave(torch.arange(batch_size), max_natom),
         number_of_edges=number_of_edges,
     )
-
-
-def _get_relative_coordinates_lattice_vectors(
-    number_of_shells: int = 1, spatial_dimension: int = 3
-) -> torch.Tensor:
-    """Get relative coordinates lattice vectors.
-
-    Get all the lattice vectors in relative coordinates from -number_of_shells to +number_of_shells,
-    in every spatial directions.
-
-    Args:
-        number_of_shells: number of shifts along lattice vectors in the positive direction.
-
-    Returns:
-        list_relative_lattice_vectors : all the lattice vectors in relative coordinates (ie, integers).
-    """
-    shifts = range(-number_of_shells, number_of_shells + 1)
-    list_relative_lattice_vectors = 1.0 * torch.tensor(
-        list(itertools.product(shifts, repeat=spatial_dimension))
-    )
-
-    return list_relative_lattice_vectors
 
 
 def _get_shifted_positions(

--- a/src/diffusion_for_multi_scale_molecular_dynamics/utils/structure_utils.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/utils/structure_utils.py
@@ -5,9 +5,11 @@ import torch
 from pykeops.torch import LazyTensor
 from pymatgen.core import Lattice, Structure
 
+from diffusion_for_multi_scale_molecular_dynamics.utils.lattice_utils import \
+    get_relative_coordinates_lattice_vectors
 from diffusion_for_multi_scale_molecular_dynamics.utils.neighbors import (
-    _get_relative_coordinates_lattice_vectors, _get_shifted_positions,
-    get_periodic_adjacency_information, get_positions_from_coordinates)
+    _get_shifted_positions, get_periodic_adjacency_information,
+    get_positions_from_coordinates)
 
 
 def create_structure(
@@ -60,7 +62,7 @@ def compute_distances_in_batch(
     zero = torch.tensor(0.0).to(device)
 
     # The relative coordinates lattice vectors have dimensions [number of lattice vectors, spatial_dimension]
-    relative_lattice_vectors = _get_relative_coordinates_lattice_vectors(
+    relative_lattice_vectors = get_relative_coordinates_lattice_vectors(
         number_of_shells=1, spatial_dimension=spatial_dimension
     ).to(device)
     number_of_relative_lattice_vectors = len(relative_lattice_vectors)

--- a/tests/models/score_network/test_score_network_equivariance.py
+++ b/tests/models/score_network/test_score_network_equivariance.py
@@ -520,10 +520,15 @@ class TestEquivarianceEGNN(BaseTestScoreEquivariance):
     def normalize(self, request):
         return request.param
 
+    @pytest.fixture(params=[1, 2, 3])
+    def nbloch(self, request):
+        return request.param
+
     @pytest.fixture(params=[("fully_connected", None), ("radial_cutoff", 3.0)])
-    def score_network_parameters(self, request, num_atom_types, normalize):
+    def score_network_parameters(self, request, num_atom_types, normalize, nbloch):
         edges, radial_cutoff = request.param
         return EGNNScoreNetworkParameters(
+            number_of_bloch_wave_shells=nbloch,
             edges=edges,
             radial_cutoff=radial_cutoff,
             num_atom_types=num_atom_types,

--- a/tests/utils/test_lattice_utils.py
+++ b/tests/utils/test_lattice_utils.py
@@ -1,8 +1,17 @@
 import pytest
 import torch
 
-from diffusion_for_multi_scale_molecular_dynamics.utils.lattice_utils import \
-    get_relative_coordinates_lattice_vectors
+from diffusion_for_multi_scale_molecular_dynamics.utils.geometric_utils import \
+    get_cubic_point_group_symmetries
+from diffusion_for_multi_scale_molecular_dynamics.utils.lattice_utils import (
+    _sort_complete_shell, get_cubic_point_group_complete_lattice_shells,
+    get_cubic_point_group_positive_normalized_bloch_wave_vectors,
+    get_relative_coordinates_lattice_vectors)
+
+
+@pytest.fixture()
+def spatial_dimension():
+    return 3
 
 
 @pytest.mark.parametrize("number_of_shells", [1, 2, 3])
@@ -63,3 +72,66 @@ def test_get_relative_coordinates_lattice_vectors_3d(number_of_shells):
     )
 
     torch.testing.assert_close(expected_lattice_vectors, computed_lattice_vectors)
+
+
+def test_sort_complete_shell():
+    shell = torch.tensor(
+        [[1, 0, 0], [0, 0, 1], [0, 0, -1], [0, -1, 0], [0, 1, 0], [-1, 0, 0]],
+        dtype=torch.int32,
+    )
+
+    expected_sorted_shell = torch.tensor(
+        [[1, 0, 0], [0, 1, 0], [0, 0, 1], [0, 0, -1], [0, -1, 0], [-1, 0, 0]],
+        dtype=torch.int32,
+    )
+
+    sorted_shell = _sort_complete_shell(shell)
+
+    torch.testing.assert_close(expected_sorted_shell, sorted_shell)
+
+
+def test_get_cubic_point_group_complete_lattice_shells(spatial_dimension):
+    number_of_complete_shells = 3
+    list_shells = get_cubic_point_group_complete_lattice_shells(
+        number_of_complete_shells=number_of_complete_shells,
+        spatial_dimension=spatial_dimension,
+    )
+
+    symmetries = get_cubic_point_group_symmetries(spatial_dimension).int()
+
+    assert len(list_shells) >= number_of_complete_shells
+
+    for shell in list_shells:
+        computed_set = set(tuple(ell) for ell in shell.numpy())
+        expected_set = set(tuple(ell) for ell in torch.matmul(symmetries, shell[0]).numpy())
+        assert computed_set == expected_set
+
+
+def test_get_cubic_point_group_positive_normalized_bloch_wave_vectors(
+    spatial_dimension,
+):
+
+    number_of_complete_shells = 3
+    list_shells = get_cubic_point_group_complete_lattice_shells(
+        number_of_complete_shells, spatial_dimension
+    )
+
+    all_lattice_vectors = torch.vstack(list_shells)
+
+    bloch_wave_vectors = get_cubic_point_group_positive_normalized_bloch_wave_vectors(
+        number_of_complete_shells, spatial_dimension
+    )
+
+    assert len(bloch_wave_vectors) == len(all_lattice_vectors) / 2
+
+    expected_set = set(tuple(ell.numpy()) for ell in all_lattice_vectors)
+    computed_set = set(tuple(ell.numpy()) for ell in bloch_wave_vectors)
+    assert computed_set.issubset(expected_set)
+
+    inversion = -torch.eye(spatial_dimension).int()
+
+    inversion_bloch_wave_vectors = torch.matmul(bloch_wave_vectors, inversion)
+    inversion_set = set(tuple(ell.numpy()) for ell in inversion_bloch_wave_vectors)
+    computed_set.update(inversion_set)
+
+    assert computed_set == expected_set

--- a/tests/utils/test_lattice_utils.py
+++ b/tests/utils/test_lattice_utils.py
@@ -1,0 +1,65 @@
+import pytest
+import torch
+
+from diffusion_for_multi_scale_molecular_dynamics.utils.lattice_utils import \
+    get_relative_coordinates_lattice_vectors
+
+
+@pytest.mark.parametrize("number_of_shells", [1, 2, 3])
+def test_get_relative_coordinates_lattice_vectors_1d(number_of_shells):
+
+    expected_lattice_vectors = []
+
+    for nx in torch.arange(-number_of_shells, number_of_shells + 1):
+        lattice_vector = torch.tensor([nx])
+        expected_lattice_vectors.append(lattice_vector)
+
+    expected_lattice_vectors = torch.stack(expected_lattice_vectors).to(
+        dtype=torch.float32
+    )
+    computed_lattice_vectors = get_relative_coordinates_lattice_vectors(
+        number_of_shells, spatial_dimension=1
+    )
+
+    torch.testing.assert_close(expected_lattice_vectors, computed_lattice_vectors)
+
+
+@pytest.mark.parametrize("number_of_shells", [1, 2, 3])
+def test_get_relative_coordinates_lattice_vectors_2d(number_of_shells):
+
+    expected_lattice_vectors = []
+
+    for nx in torch.arange(-number_of_shells, number_of_shells + 1):
+        for ny in torch.arange(-number_of_shells, number_of_shells + 1):
+            lattice_vector = torch.tensor([nx, ny])
+            expected_lattice_vectors.append(lattice_vector)
+
+    expected_lattice_vectors = torch.stack(expected_lattice_vectors).to(
+        dtype=torch.float32
+    )
+    computed_lattice_vectors = get_relative_coordinates_lattice_vectors(
+        number_of_shells, spatial_dimension=2
+    )
+
+    torch.testing.assert_close(expected_lattice_vectors, computed_lattice_vectors)
+
+
+@pytest.mark.parametrize("number_of_shells", [1, 2, 3])
+def test_get_relative_coordinates_lattice_vectors_3d(number_of_shells):
+
+    expected_lattice_vectors = []
+
+    for nx in torch.arange(-number_of_shells, number_of_shells + 1):
+        for ny in torch.arange(-number_of_shells, number_of_shells + 1):
+            for nz in torch.arange(-number_of_shells, number_of_shells + 1):
+                lattice_vector = torch.tensor([nx, ny, nz])
+                expected_lattice_vectors.append(lattice_vector)
+
+    expected_lattice_vectors = torch.stack(expected_lattice_vectors).to(
+        dtype=torch.float32
+    )
+    computed_lattice_vectors = get_relative_coordinates_lattice_vectors(
+        number_of_shells, spatial_dimension=3
+    )
+
+    torch.testing.assert_close(expected_lattice_vectors, computed_lattice_vectors)

--- a/tests/utils/test_neighbors.py
+++ b/tests/utils/test_neighbors.py
@@ -7,9 +7,11 @@ from pymatgen.core import Lattice, Structure
 
 from diffusion_for_multi_scale_molecular_dynamics.utils.basis_transformations import \
     get_positions_from_coordinates
+from diffusion_for_multi_scale_molecular_dynamics.utils.lattice_utils import \
+    get_relative_coordinates_lattice_vectors
 from diffusion_for_multi_scale_molecular_dynamics.utils.neighbors import (
-    AdjacencyInfo, _get_relative_coordinates_lattice_vectors,
-    _get_shifted_positions, _get_shortest_distance_that_crosses_unit_cell,
+    AdjacencyInfo, _get_shifted_positions,
+    _get_shortest_distance_that_crosses_unit_cell,
     _get_vectors_from_multiple_indices, get_periodic_adjacency_information,
     shift_adjacency_matrix_indices_for_graph_batching)
 from tests.fake_data_utils import find_aligning_permutation
@@ -64,7 +66,7 @@ def positions(relative_coordinates, basis_vectors):
 
 @pytest.fixture
 def lattice_vectors(batch_size, basis_vectors, number_of_shells, spatial_dimension):
-    relative_lattice_vectors = _get_relative_coordinates_lattice_vectors(
+    relative_lattice_vectors = get_relative_coordinates_lattice_vectors(
         number_of_shells, spatial_dimension
     )
     batched_relative_lattice_vectors = relative_lattice_vectors.repeat(batch_size, 1, 1)
@@ -256,66 +258,6 @@ def test_get_periodic_neighbour_indices_and_displacements_large_cutoff(
         get_periodic_adjacency_information(
             relative_coordinates, basis_vectors, large_radial_cutoff, spatial_dimension=spatial_dimension
         )
-
-
-@pytest.mark.parametrize("number_of_shells", [1, 2, 3])
-def test_get_relative_coordinates_lattice_vectors_1d(number_of_shells):
-
-    expected_lattice_vectors = []
-
-    for nx in torch.arange(-number_of_shells, number_of_shells + 1):
-        lattice_vector = torch.tensor([nx])
-        expected_lattice_vectors.append(lattice_vector)
-
-    expected_lattice_vectors = torch.stack(expected_lattice_vectors).to(
-        dtype=torch.float32
-    )
-    computed_lattice_vectors = _get_relative_coordinates_lattice_vectors(
-        number_of_shells, spatial_dimension=1
-    )
-
-    torch.testing.assert_close(expected_lattice_vectors, computed_lattice_vectors)
-
-
-@pytest.mark.parametrize("number_of_shells", [1, 2, 3])
-def test_get_relative_coordinates_lattice_vectors_2d(number_of_shells):
-
-    expected_lattice_vectors = []
-
-    for nx in torch.arange(-number_of_shells, number_of_shells + 1):
-        for ny in torch.arange(-number_of_shells, number_of_shells + 1):
-            lattice_vector = torch.tensor([nx, ny])
-            expected_lattice_vectors.append(lattice_vector)
-
-    expected_lattice_vectors = torch.stack(expected_lattice_vectors).to(
-        dtype=torch.float32
-    )
-    computed_lattice_vectors = _get_relative_coordinates_lattice_vectors(
-        number_of_shells, spatial_dimension=2
-    )
-
-    torch.testing.assert_close(expected_lattice_vectors, computed_lattice_vectors)
-
-
-@pytest.mark.parametrize("number_of_shells", [1, 2, 3])
-def test_get_relative_coordinates_lattice_vectors_3d(number_of_shells):
-
-    expected_lattice_vectors = []
-
-    for nx in torch.arange(-number_of_shells, number_of_shells + 1):
-        for ny in torch.arange(-number_of_shells, number_of_shells + 1):
-            for nz in torch.arange(-number_of_shells, number_of_shells + 1):
-                lattice_vector = torch.tensor([nx, ny, nz])
-                expected_lattice_vectors.append(lattice_vector)
-
-    expected_lattice_vectors = torch.stack(expected_lattice_vectors).to(
-        dtype=torch.float32
-    )
-    computed_lattice_vectors = _get_relative_coordinates_lattice_vectors(
-        number_of_shells, spatial_dimension=3
-    )
-
-    torch.testing.assert_close(expected_lattice_vectors, computed_lattice_vectors)
 
 
 @pytest.mark.parametrize("number_of_shells", [1, 2])


### PR DESCRIPTION
Here I add the possibility of using more reciprocal lattice vectors (K vectors) in complete shells in the EGNN architecture. 

Referring to our Latex document, the embedding to high-dimensional  Euclidean space takes the form
<img width="652" alt="Screenshot 2025-02-02 at 6 46 06 AM" src="https://github.com/user-attachments/assets/e1d1c53d-8ebb-4cd8-a74c-b861a3675b4e" />

Since we have inversion symmetry, and we don't want to manipulate complex numbers, this becomes
<img width="509" alt="Screenshot 2025-02-02 at 6 47 18 AM" src="https://github.com/user-attachments/assets/05d0fa2b-1016-4466-9c55-927da7d74546" />

and the model takes the form
<img width="1018" alt="Screenshot 2025-02-02 at 6 48 09 AM" src="https://github.com/user-attachments/assets/646a5fcc-2754-4fcd-9385-bee32f5de4ee" />

To preserve point group symmetry, the K vectors must be present in complete symmetry shells. 

The previous code was equivalent to limiting ourselves to `number_of_shells = 1`. This new code allows use to use more shells. 

This is probably not a huge improvement, but it was silly to limit ourselves to the first shell: comparable papers use "positional embedding" with many more Fourier modes.

