### PR TITLE
Increment Pytorch-Lightning

### DIFF
--- a/analysis_and_sanity_checks/atom_types_only_experiments/patches/fixed_position_data_module.py
+++ b/analysis_and_sanity_checks/atom_types_only_experiments/patches/fixed_position_data_module.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from typing import Any, AnyStr, Dict, Optional
 
 import datasets
-import pytorch_lightning as pl
+import lightning as pl
 import torch
 from fixed_position_noising_transform import FixedPositionNoisingTransform
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ dependencies = [
     "pytest-mock==3.12.0",
     "pytest-xdist>=3.6.1",
     "pytest==8.3.3",
-    "pytorch-lightning>=2.4.0",
     "pytype==2024.2.13",
     "pyyaml==6.0.1",
     "rich==13.7.1",
@@ -53,6 +52,7 @@ dependencies = [
     "torchode==0.2.0",
     "torchsde==0.2.6",
     "tqdm==4.64.0",
+    "lightning>=2.5.1",
 ]
 
 [project.optional-dependencies]

--- a/src/diffusion_for_multi_scale_molecular_dynamics/callbacks/callback_loader.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/callbacks/callback_loader.py
@@ -1,7 +1,7 @@
 from typing import Any, AnyStr, Dict
 
-from pytorch_lightning import Callback
-from pytorch_lightning.callbacks import LearningRateMonitor
+from lightning import Callback
+from lightning.pytorch.callbacks import LearningRateMonitor
 
 from diffusion_for_multi_scale_molecular_dynamics.callbacks.loss_monitoring_callback import \
     instantiate_loss_monitoring_callback

--- a/src/diffusion_for_multi_scale_molecular_dynamics/callbacks/loss_monitoring_callback.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/callbacks/loss_monitoring_callback.py
@@ -2,8 +2,8 @@ from typing import Any, AnyStr, Dict
 
 import numpy as np
 import torch
+from lightning import Callback
 from matplotlib import pyplot as plt
-from pytorch_lightning import Callback
 
 from diffusion_for_multi_scale_molecular_dynamics.analysis import (
     PLEASANT_FIG_SIZE, PLOT_STYLE_PATH)

--- a/src/diffusion_for_multi_scale_molecular_dynamics/callbacks/sampling_visualization_callback.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/callbacks/sampling_visualization_callback.py
@@ -6,8 +6,8 @@ from typing import Any, AnyStr, Dict
 
 import numpy as np
 import torch
+from lightning import Callback, LightningModule, Trainer
 from matplotlib import pyplot as plt
-from pytorch_lightning import Callback, LightningModule, Trainer
 
 from diffusion_for_multi_scale_molecular_dynamics.analysis import (
     PLEASANT_FIG_SIZE, PLOT_STYLE_PATH)

--- a/src/diffusion_for_multi_scale_molecular_dynamics/callbacks/score_viewer_callback.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/callbacks/score_viewer_callback.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 from typing import Any, AnyStr, Dict
 
+from lightning import Callback, LightningModule, Trainer
 from matplotlib import pyplot as plt
-from pytorch_lightning import Callback, LightningModule, Trainer
 
 from diffusion_for_multi_scale_molecular_dynamics.analysis.score_viewer import (
     ScoreViewer, ScoreViewerParameters)

--- a/src/diffusion_for_multi_scale_molecular_dynamics/callbacks/standard_callbacks.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/callbacks/standard_callbacks.py
@@ -2,8 +2,8 @@ import logging
 import os
 from typing import Any, AnyStr, Dict
 
-from pytorch_lightning import Callback
-from pytorch_lightning.callbacks import (EarlyStopping, ModelCheckpoint,
+from lightning import Callback
+from lightning.pytorch.callbacks import (EarlyStopping, ModelCheckpoint,
                                          RichProgressBar)
 
 logger = logging.getLogger(__name__)

--- a/src/diffusion_for_multi_scale_molecular_dynamics/data/diffusion/gaussian_data_module.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/data/diffusion/gaussian_data_module.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import List, Optional
 
 import einops
-import pytorch_lightning as pl
+import lightning as pl
 import torch
 from torch.utils.data import DataLoader
 

--- a/src/diffusion_for_multi_scale_molecular_dynamics/data/diffusion/instantiate_data_module.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/data/diffusion/instantiate_data_module.py
@@ -3,7 +3,7 @@ import argparse
 import logging
 from typing import Any, AnyStr, Dict
 
-import pytorch_lightning as pl
+import lightning as pl
 
 from diffusion_for_multi_scale_molecular_dynamics.data.diffusion.gaussian_data_module import (
     GaussianDataModule, GaussianDataModuleParameters)

--- a/src/diffusion_for_multi_scale_molecular_dynamics/data/diffusion/lammps_for_diffusion_data_module.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/data/diffusion/lammps_for_diffusion_data_module.py
@@ -7,7 +7,7 @@ from functools import partial
 from typing import Dict, Optional
 
 import datasets
-import pytorch_lightning as pl
+import lightning as pl
 import torch
 import torch.nn.functional as F
 from torch.utils.data import DataLoader

--- a/src/diffusion_for_multi_scale_molecular_dynamics/loggers/logger_loader.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/loggers/logger_loader.py
@@ -5,9 +5,9 @@ from typing import Any, AnyStr, Dict, List, Union
 
 import orion
 import yaml
-from matplotlib import pyplot as plt
-from pytorch_lightning.loggers import (CometLogger, CSVLogger, Logger,
+from lightning.pytorch.loggers import (CometLogger, CSVLogger, Logger,
                                        TensorBoardLogger)
+from matplotlib import pyplot as plt
 
 
 def get_run_name(hyper_params: Dict[AnyStr, Any]) -> str:

--- a/src/diffusion_for_multi_scale_molecular_dynamics/models/axl_diffusion_lightning_model.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/models/axl_diffusion_lightning_model.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import Any, Optional
 
 import einops
-import pytorch_lightning as pl
+import lightning as pl
 import torch
 
 from diffusion_for_multi_scale_molecular_dynamics.generators.instantiate_generator import \

--- a/src/diffusion_for_multi_scale_molecular_dynamics/train_diffusion.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/train_diffusion.py
@@ -6,8 +6,7 @@ import os
 import shutil
 import typing
 
-import pytorch_lightning
-import pytorch_lightning as pl
+import lightning as pl
 import yaml
 
 from diffusion_for_multi_scale_molecular_dynamics.callbacks.callback_loader import \
@@ -123,7 +122,7 @@ def run(args: argparse.Namespace, output_dir, hyper_params):
     # __TODO__ change the hparam that are used from the training algorithm
     # (and NOT the model - these will be specified in the model itself)
     if hyper_params["seed"] is not None:
-        pytorch_lightning.seed_everything(hyper_params["seed"])
+        pl.seed_everything(hyper_params["seed"])
 
     ElementTypes.validate_elements(hyper_params["elements"])
 

--- a/tests/models/test_axl_diffusion_lightning_model.py
+++ b/tests/models/test_axl_diffusion_lightning_model.py
@@ -4,7 +4,7 @@ from typing import Tuple
 import numpy as np
 import pytest
 import torch
-from pytorch_lightning import LightningDataModule, Trainer
+from lightning import LightningDataModule, Trainer
 from torch.utils.data import DataLoader, default_collate, random_split
 
 from diffusion_for_multi_scale_molecular_dynamics.data.diffusion.noising_transform import \

--- a/uv.lock
+++ b/uv.lock
@@ -1,10 +1,14 @@
 version = 1
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version < '3.11'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version >= '3.13'",
+    "python_full_version < '3.11' and sys_platform != 'linux'",
+    "python_full_version < '3.11' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and sys_platform != 'linux'",
+    "python_full_version == '3.11.*' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and sys_platform != 'linux'",
+    "python_full_version == '3.12.*' and sys_platform == 'linux'",
+    "python_full_version >= '3.13' and sys_platform != 'linux'",
+    "python_full_version >= '3.13' and sys_platform == 'linux'",
 ]
 
 [[package]]
@@ -813,6 +817,7 @@ dependencies = [
     { name = "jupyter" },
     { name = "kaleido" },
     { name = "lammps" },
+    { name = "lightning" },
     { name = "mace-torch" },
     { name = "maml" },
     { name = "matplotlib" },
@@ -828,7 +833,6 @@ dependencies = [
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-xdist" },
-    { name = "pytorch-lightning" },
     { name = "pytype" },
     { name = "pyyaml" },
     { name = "rich" },
@@ -867,6 +871,7 @@ requires-dist = [
     { name = "jupyter", specifier = "==1.0.0" },
     { name = "kaleido", specifier = "==0.2.1" },
     { name = "lammps", specifier = ">=2024.8.29.1.0" },
+    { name = "lightning", specifier = ">=2.5.1" },
     { name = "mace-torch", specifier = "==0.3.4" },
     { name = "maml", specifier = "==2023.9.9" },
     { name = "matplotlib", specifier = "==3.8.3" },
@@ -883,7 +888,6 @@ requires-dist = [
     { name = "pytest-cov", specifier = "==3.0.0" },
     { name = "pytest-mock", specifier = "==3.12.0" },
     { name = "pytest-xdist", specifier = ">=3.6.1" },
-    { name = "pytorch-lightning", specifier = ">=2.4.0" },
     { name = "pytype", specifier = "==2024.2.13" },
     { name = "pyyaml", specifier = "==6.0.1" },
     { name = "rich", specifier = "==13.7.1" },
@@ -1781,7 +1785,7 @@ dependencies = [
     { name = "overrides" },
     { name = "packaging" },
     { name = "prometheus-client" },
-    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "pywinpty", marker = "os_name == 'nt' and sys_platform != 'linux'" },
     { name = "pyzmq" },
     { name = "send2trash" },
     { name = "terminado" },
@@ -1799,7 +1803,7 @@ name = "jupyter-server-terminals"
 version = "0.5.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "pywinpty", marker = "os_name == 'nt' and sys_platform != 'linux'" },
     { name = "terminado" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/d5/562469734f476159e99a55426d697cbf8e7eb5efe89fb0e0b4f83a3d3459/jupyter_server_terminals-0.5.3.tar.gz", hash = "sha256:5ae0295167220e9ace0edcfdb212afd2b01ee8d179fe6f23c899590e9b8a5269", size = 31430 }
@@ -2060,17 +2064,37 @@ wheels = [
 ]
 
 [[package]]
+name = "lightning"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fsspec", extra = ["http"] },
+    { name = "lightning-utilities" },
+    { name = "packaging" },
+    { name = "pytorch-lightning" },
+    { name = "pyyaml" },
+    { name = "torch" },
+    { name = "torchmetrics" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/53/21a834e03317d04cc3db7307d4c19af94c0db43b9001e8fabb8d150c5e69/lightning-2.5.1.tar.gz", hash = "sha256:aca88f8abf3fc38d8b40c1f82ce481f4379c2b181a6eeeb9217db0aba8e40736", size = 630918 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/eb/45f6629b92cb4ed38854d5b76f9f668ff58404a4b9ec1abefa98502afd98/lightning-2.5.1-py3-none-any.whl", hash = "sha256:512cbf9e80859f331b329536b2e2f90776e6f8a399048745bb4dabacc36e2850", size = 818892 },
+]
+
+[[package]]
 name = "lightning-utilities"
-version = "0.11.8"
+version = "0.14.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
     { name = "setuptools" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/ab/0c421d19e316420a2d54a2da5ae4a4dcd557928ccf7953dbbe4b4eee34d6/lightning_utilities-0.11.8.tar.gz", hash = "sha256:8dfbdc6c52f9847efc948dc462ab8bebb4f4e9a43bd69c82c1b1da484dac20e6", size = 28614 }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/bb/63a6a8c9e7a96b6ba92647fa5b1595c2dbee29f8178705adb4704d82ecba/lightning_utilities-0.14.3.tar.gz", hash = "sha256:37e2f83f273890052955a44054382c211a303012ee577619efbaa5df9e65e9f5", size = 30346 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/5d/4c4672025c23a305231a81bf492f65aa3ea0965a89f9ca369a9ee7d47fd9/lightning_utilities-0.11.8-py3-none-any.whl", hash = "sha256:a57edb34a44258f0c61eed8b8b88926766e9052f5e60bbe69e4871a2b2bfd970", size = 26816 },
+    { url = "https://files.pythonhosted.org/packages/1a/c1/31b3184cba7b257a4a3b5ca5b88b9204ccb7aa02fe3c992280899293ed54/lightning_utilities-0.14.3-py3-none-any.whl", hash = "sha256:4ab9066aa36cd7b93a05713808901909e96cc3f187ea6fd3052b2fd91313b468", size = 28894 },
 ]
 
 [[package]]
@@ -2667,7 +2691,7 @@ name = "nvidia-cudnn-cu12"
 version = "8.9.2.26"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ff/74/a2e2be7fb83aaedec84f391f082cf765dfb635e7caa9b49065f73e4835d8/nvidia_cudnn_cu12-8.9.2.26-py3-none-manylinux1_x86_64.whl", hash = "sha256:5ccb288774fdfb07a7e7025ffec286971c06d8d7b4fb162525334616d7629ff9", size = 731725872 },
@@ -2694,9 +2718,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.4.5.107"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/1d/8de1e5c67099015c834315e333911273a8c6aaba78923dd1d1e25fc5f217/nvidia_cusolver_cu12-11.4.5.107-py3-none-manylinux1_x86_64.whl", hash = "sha256:8a7ec542f0412294b15072fa7dab71d31334014a69f953004ea7a118206fe0dd", size = 124161928 },
@@ -2707,7 +2731,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.1.0.106"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/65/5b/cfaeebf25cd9fdec14338ccb16f6b2c4c7fa9163aefcf057d86b9cc248bb/nvidia_cusparse_cu12-12.1.0.106-py3-none-manylinux1_x86_64.whl", hash = "sha256:f3b50f42cf363f86ab21f720998517a659a48131e8d538dc02f8768237bd884c", size = 195958278 },
@@ -3635,7 +3659,7 @@ wheels = [
 
 [[package]]
 name = "pytorch-lightning"
-version = "2.4.0"
+version = "2.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fsspec", extra = ["http"] },
@@ -3647,9 +3671,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/f0/3207bd5019c43899efbb5444da263577497a5c4dc82719633a3bf63d8f45/pytorch-lightning-2.4.0.tar.gz", hash = "sha256:6aa897fd9d6dfa7b7b49f37c2f04e13592861831d08deae584dfda423fdb71c8", size = 625320 }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/75/b8ac01fd3974328ae9239c39550d48899b2fa1b0e064c01615b72a574082/pytorch_lightning-2.5.1.tar.gz", hash = "sha256:27a8adb799c13b8202afad518352248d61303fb230ec1f9fa60e0f81d431d6b1", size = 634309 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/d2/ecd65ff1e0b1ca79f9785dd65d5ced7ec2643a828068aaa24e47e4c84a14/pytorch_lightning-2.4.0-py3-none-any.whl", hash = "sha256:9ac7935229ac022ef06994c928217ed37f525ac6700f7d4fc57009624570e655", size = 815151 },
+    { url = "https://files.pythonhosted.org/packages/82/ff/5701f79317a1a03e5ee8a1bf48e7273a8445162a2774e51fc06411a67c89/pytorch_lightning-2.5.1-py3-none-any.whl", hash = "sha256:0bfbbd3ad80281d3062f5d8029a759093bd969ff8162e7c1fe2918552b269f9e", size = 822982 },
 ]
 
 [[package]]
@@ -4640,7 +4664,7 @@ version = "0.18.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ptyprocess", marker = "os_name != 'nt'" },
-    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "pywinpty", marker = "os_name == 'nt' and sys_platform != 'linux'" },
     { name = "tornado" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8a/11/965c6fd8e5cc254f1fe142d547387da17a8ebfd75a3455f637c663fb38a0/terminado-0.18.1.tar.gz", hash = "sha256:de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e", size = 32701 }
@@ -4764,7 +4788,7 @@ wheels = [
 
 [[package]]
 name = "torchmetrics"
-version = "1.5.0"
+version = "1.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lightning-utilities" },
@@ -4772,9 +4796,9 @@ dependencies = [
     { name = "packaging" },
     { name = "torch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/11/3d/d14914f15b19ce971215973305d30b9a673b7fa0c6796076e149c11765a0/torchmetrics-1.5.0.tar.gz", hash = "sha256:c18e68bab4104ad7d2285af601ddc6dc04f9f3b7cafaa8ad13fa1dcc539e33b6", size = 521148 }
+sdist = { url = "https://files.pythonhosted.org/packages/28/c4/2d921ccf7433ee6d8d6edeaca238674cbbc74528120631c662014795c645/torchmetrics-1.7.1.tar.gz", hash = "sha256:0ac1a0e90d2375866ceb5d3868720c6df7d7d0c5729b7ad36e92c897c6af70c2", size = 565045 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/94/e5ee3f8a99d7494e58f5e608ae8af0906e47b0bbf91ea7c9d8076418887e/torchmetrics-1.5.0-py3-none-any.whl", hash = "sha256:a65628e0ea04c98bff84f2152c5a48416cbb8dc41c6e4ba44204cfc6ace2a30f", size = 890490 },
+    { url = "https://files.pythonhosted.org/packages/e0/ee/4d0a7213a6f412afb3483031009a3b970dd7bed3be24de95ab04fba1c05a/torchmetrics-1.7.1-py3-none-any.whl", hash = "sha256:9a4c45edbd0a1844cc1540c9e71bfbe0ee783a2ed997344d947fefecac90dbb9", size = 961489 },
 ]
 
 [[package]]
@@ -4909,7 +4933,7 @@ name = "triton"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock" },
+    { name = "filelock", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/95/05/ed974ce87fe8c8843855daa2136b3409ee1c126707ab54a8b72815c08b49/triton-2.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a2294514340cfe4e8f4f9e5c66c702744c4a117d25e618bd08469d0bfed1e2e5", size = 167900779 },


### PR DESCRIPTION
I was playing with matgl, and there was a naming clash. 

The preferred way of naming "pytorch lightning" is just "lightning". They are dragging a nice name confusion since 2022
(see https://github.com/Lightning-AI/pytorch-lightning/discussions/16688). Both `pytorch-lightning` and `lightning` are used, but the latter is preferred. 

I observed a subtle collision between matgl and our old fashioned naming scheme (long boring story). 

I propose to just get on board with the new naming convention. I also increment the library version to the latest (2.5.1). This should have no effect on our code.