### PR TITLE
adding information dicts with sample makers

### DIFF
--- a/src/diffusion_for_multi_scale_molecular_dynamics/active_learning_loop/active_learning.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/active_learning_loop/active_learning.py
@@ -1,7 +1,7 @@
 import logging
 import time
 from pathlib import Path
-from typing import List, Tuple
+from typing import Any, Dict, List, Tuple
 
 import numpy as np
 import pandas as pd
@@ -17,6 +17,8 @@ from diffusion_for_multi_scale_molecular_dynamics.active_learning_loop.sample_ma
     BaseSampleMaker
 from diffusion_for_multi_scale_molecular_dynamics.active_learning_loop.sample_maker.conversion_utils import (
     convert_axl_to_structure, convert_structure_to_axl)
+from diffusion_for_multi_scale_molecular_dynamics.active_learning_loop.sample_maker.namespace import (
+    AXL_STRUCTURE_IN_NEW_BOX, AXL_STRUCTURE_IN_ORIGINAL_BOX)
 from diffusion_for_multi_scale_molecular_dynamics.active_learning_loop.single_point_calculators.base_single_point_calculator import (  # noqa
     BaseSinglePointCalculator, SinglePointCalculation)
 from diffusion_for_multi_scale_molecular_dynamics.active_learning_loop.trainer.flare_trainer import \
@@ -40,23 +42,28 @@ class ActiveLearning:
             * label samples
             * add labels to SGP; retrain SGP
     """
-    def __init__(self, oracle_single_point_claculator: BaseSinglePointCalculator,
-                 sample_maker: BaseSampleMaker,
-                 artn_driver: ArtnDriver,
-                 ):
+
+    def __init__(
+        self,
+        oracle_single_point_calculator: BaseSinglePointCalculator,
+        sample_maker: BaseSampleMaker,
+        artn_driver: ArtnDriver,
+    ):
         """Init method.
 
         Args:
-            oracle_single_point_claculator: class responsible for generating of ground truth labels.
+            oracle_single_point_calculator: class responsible for generating of ground truth labels.
             sample_maker: class responsible for generating samples for active learning.
             artn_driver: class responsible for running LAMMPS + ARTn.
 
         """
-        self.oracle_single_point_claculator = oracle_single_point_claculator
+        self.oracle_single_point_calculator = oracle_single_point_calculator
         self.sample_maker = sample_maker
         self.artn_driver = artn_driver
 
-    def _get_uncertain_structure_and_uncertainties(self, artn_working_directory: Path) -> Tuple[Structure, np.ndarray]:
+    def _get_uncertain_structure_and_uncertainties(
+        self, artn_working_directory: Path
+    ) -> Tuple[Structure, np.ndarray]:
         """Get uncertain structure.
 
         This method assumes the CONVENTION that the ARTn + LAMMPS run will produce a file
@@ -65,34 +72,83 @@ class ActiveLearning:
         lammps_dump_path = artn_working_directory / "uncertain_dump.yaml"
         assert lammps_dump_path.is_file(), f"The file {lammps_dump_path} is missing."
 
-        list_structures, _, _, list_uncertainties = extract_all_fields_from_dump(lammps_dump_path)
+        list_structures, _, _, list_uncertainties = extract_all_fields_from_dump(
+            lammps_dump_path
+        )
         uncertain_structure = list_structures[0]
         uncertainties = list_uncertainties[0]
         return uncertain_structure, uncertainties
 
-    def _make_samples(self, structure: Structure, uncertainty_per_atom: np.ndarray) -> List[Structure]:
+    def _make_samples(
+        self, structure: Structure, uncertainty_per_atom: np.ndarray
+    ) -> Tuple[List[Structure], List[Dict[str, Any]]]:
         """Make samples."""
         axl_structure = convert_structure_to_axl(structure)
-        list_sample_axl_structures = self.sample_maker.make_samples(axl_structure, uncertainty_per_atom)
-        return [convert_axl_to_structure(axl_structure) for axl_structure in list_sample_axl_structures]
+        list_sample_axl_structures, list_sample_additional_information = (
+            self.sample_maker.make_samples(axl_structure, uncertainty_per_atom)
+        )
+        converted_list_sample_axl_structures = [
+            convert_axl_to_structure(axl_structure)
+            for axl_structure in list_sample_axl_structures
+        ]
+        converted_list_additional_information = [
+            self._convert_axl_to_structure_in_dict(sample_info)
+            for sample_info in list_sample_additional_information
+        ]
+        return (
+            converted_list_sample_axl_structures,
+            converted_list_additional_information,
+        )
 
-    def _convert_single_point_calculations_to_dataframe(self,
-                                                        list_single_point_calculations:
-                                                        List[SinglePointCalculation]) -> pd.DataFrame:
+    @staticmethod
+    def _convert_axl_to_structure_in_dict(
+        sample_additional_information: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Convert AXL elements of an additional information dictionary to pymatgen structure.
+
+        Args:
+            sample_additional_information: additional information about a sample in a dictionary.
+
+        Returns:
+            new_structures: additional information about a sample in a dictionary with AXL as Structure
+        """
+        converted_info = {}
+        for k, v in sample_additional_information:
+            if k in [AXL_STRUCTURE_IN_ORIGINAL_BOX, AXL_STRUCTURE_IN_NEW_BOX]:
+                converted_info[k] = convert_axl_to_structure(v)
+            else:
+                converted_info[k] = v
+        return converted_info
+
+    def _convert_single_point_calculations_to_dataframe(
+        self,
+        list_single_point_calculations: List[SinglePointCalculation],
+        list_sample_information: List[Dict[str, Any]],
+    ) -> pd.DataFrame:
         """Convert single point calculations to dataframe."""
         rows = []
-        for calculation in list_single_point_calculations:
-            row = dict(calculation_type=calculation.calculation_type,
-                       structure=calculation.structure,
-                       forces=calculation.forces,
-                       energy=calculation.energy)
+        for calculation, sample_information in zip(
+            list_single_point_calculations, list_sample_information
+        ):
+            row = dict(
+                calculation_type=calculation.calculation_type,
+                structure=calculation.structure,
+                forces=calculation.forces,
+                energy=calculation.energy,
+                sample_information=sample_information,
+            )
             rows.append(row)
 
         df = pd.DataFrame(data=rows)
         return df
 
-    def run_campaign(self, uncertainty_threshold: float, flare_trainer: FlareTrainer,
-                     working_directory: Path, maximum_number_of_rounds: int = 100):
+    def run_campaign(
+        self,
+        uncertainty_threshold: float,
+        flare_trainer: FlareTrainer,
+        working_directory: Path,
+        maximum_number_of_rounds: int = 100,
+    ):
         """Run campaign.
 
         Perform a full campaign of active learning.
@@ -106,13 +162,14 @@ class ActiveLearning:
             maximum_number_of_rounds: maximum number of active learning rounds. This is useful to avoid
                 infinite loops...
         """
-        assert not working_directory.is_dir(), \
-            f"The directory {working_directory} already exists! Stopping now to avoid overwriting results."
+        assert (
+            not working_directory.is_dir()
+        ), f"The directory {working_directory} already exists! Stopping now to avoid overwriting results."
         working_directory.mkdir(parents=True, exist_ok=True)
         logger = logging.getLogger("campaign")
-        configure_logging(experiment_dir=str(working_directory),
-                          logger=logger,
-                          log_to_console=True)
+        configure_logging(
+            experiment_dir=str(working_directory), logger=logger, log_to_console=True
+        )
         logger.info("Starting Active Learning Simulation")
 
         round_number = 0
@@ -123,20 +180,27 @@ class ActiveLearning:
 
             current_sub_directory = working_directory / f"round_{round_number}"
 
-            mapped_coefficients_directory = current_sub_directory / "FLARE_mapped_coefficients"
+            mapped_coefficients_directory = (
+                current_sub_directory / "FLARE_mapped_coefficients"
+            )
             mapped_coefficients_directory.mkdir(parents=True, exist_ok=True)
 
             # The artn_driver will create this directory.
             artn_working_directory = current_sub_directory / "lammps_artn"
 
             pair_coeff_file_path, mapped_uncertainty_file_path = (
-                flare_trainer.write_mapped_model_to_disk(mapped_coefficients_directory, version=round_number))
+                flare_trainer.write_mapped_model_to_disk(
+                    mapped_coefficients_directory, version=round_number
+                )
+            )
 
             logger.info("  Launching ARTn simulation...")
-            calculation_state = self.artn_driver.run(working_directory=artn_working_directory,
-                                                     uncertainty_threshold=uncertainty_threshold,
-                                                     pair_coeff_file_path=pair_coeff_file_path,
-                                                     mapped_uncertainty_file_path=mapped_uncertainty_file_path)
+            calculation_state = self.artn_driver.run(
+                working_directory=artn_working_directory,
+                uncertainty_threshold=uncertainty_threshold,
+                pair_coeff_file_path=pair_coeff_file_path,
+                mapped_uncertainty_file_path=mapped_uncertainty_file_path,
+            )
             logger.info(f"  ARTn state is {calculation_state}")
 
             if calculation_state == CalculationState.SUCCESS:
@@ -145,23 +209,36 @@ class ActiveLearning:
 
             logger.info("  Extracting uncertain structure from ARTn work directory...")
             uncertain_structure, uncertainty_per_atom = (
-                self._get_uncertain_structure_and_uncertainties(artn_working_directory))
+                self._get_uncertain_structure_and_uncertainties(artn_working_directory)
+            )
 
-            number_of_uncertain_envs = np.sum(uncertainty_per_atom > uncertainty_threshold)
-            logger.info(f" -> There are {number_of_uncertain_envs} environments with uncertainty above the threshold.")
+            number_of_uncertain_envs = np.sum(
+                uncertainty_per_atom > uncertainty_threshold
+            )
+            logger.info(
+                f" -> There are {number_of_uncertain_envs} environments with uncertainty above the threshold."
+            )
 
             logger.info("  Making new samples based on uncertainties.")
-            list_sample_structures = self._make_samples(uncertain_structure, uncertainty_per_atom)
+            list_sample_structures, list_sample_information = self._make_samples(
+                uncertain_structure, uncertainty_per_atom
+            )
 
             logger.info("  Labelling samples with oracle...")
             time1 = time.time()
-            list_single_point_calculations = \
-                [self.oracle_single_point_claculator.calculate(structure) for structure in list_sample_structures]
+            list_single_point_calculations = [
+                self.oracle_single_point_calculator.calculate(structure)
+                for structure in list_sample_structures
+            ]
             time2 = time.time()
-            logger.info(f" -> It took {time2- time1: 6.2e} seconds to compute labels with Oracle.")
+            logger.info(
+                f" -> It took {time2- time1: 6.2e} seconds to compute labels with Oracle."
+            )
 
             logger.info("  Converting labelled samples and writing pickle to disk.")
-            oracle_df = self._convert_single_point_calculations_to_dataframe(list_single_point_calculations)
+            oracle_df = self._convert_single_point_calculations_to_dataframe(
+                list_single_point_calculations, list_sample_information
+            )
 
             oracle_directory = current_sub_directory / "oracle"
             oracle_directory.mkdir(parents=True, exist_ok=True)
@@ -175,9 +252,13 @@ class ActiveLearning:
                 #   This may not be trivial when using a sample maker. For now, since
                 #   I "know" it's NoOp, I can use the right indices.
                 mask = np.where(uncertainty_per_atom > uncertainty_threshold)[0]
-                active_environment_indices = list(np.arange(len(uncertainty_per_atom))[mask])
-                flare_trainer.add_labelled_structure(single_point_calculation,
-                                                     active_environment_indices=active_environment_indices)
+                active_environment_indices = list(
+                    np.arange(len(uncertainty_per_atom))[mask]
+                )
+                flare_trainer.add_labelled_structure(
+                    single_point_calculation,
+                    active_environment_indices=active_environment_indices,
+                )
 
             logger.info("  Fitting the FLARE hyperparameters")
             flare_trainer.fit_hyperparameters()

--- a/src/diffusion_for_multi_scale_molecular_dynamics/active_learning_loop/sample_maker/base_sample_maker.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/active_learning_loop/sample_maker/base_sample_maker.py
@@ -1,12 +1,14 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import torch
 
 from diffusion_for_multi_scale_molecular_dynamics.active_learning_loop.excisor.base_excisor import \
     BaseEnvironmentExcision
+from diffusion_for_multi_scale_molecular_dynamics.active_learning_loop.sample_maker.namespace import (
+    AXL_STRUCTURE_IN_NEW_BOX, AXL_STRUCTURE_IN_ORIGINAL_BOX)
 from diffusion_for_multi_scale_molecular_dynamics.namespace import AXL
 from diffusion_for_multi_scale_molecular_dynamics.utils.basis_transformations import (
     get_positions_from_coordinates, get_reciprocal_basis_vectors,
@@ -61,7 +63,7 @@ class BaseSampleMaker(ABC):
         self,
         structure: AXL,
         uncertainty_per_atom: np.array,
-    ) -> List[AXL]:
+    ) -> Tuple[List[AXL], List[Dict[str, Any]]]:
         """Create samples based on the provided structure.
 
         Args:
@@ -140,9 +142,9 @@ class NoOpSampleMaker(BaseSampleMaker):
         self,
         structure: AXL,
         uncertainty_per_atom: np.array,
-    ) -> List[AXL]:
+    ) -> Tuple[List[AXL], List[Dict[str, Any]]]:
         """Noop make samples."""
-        return [structure]
+        return [structure], [{}]
 
     def filter_made_samples(self, structures: List[AXL]) -> List[AXL]:
         """Noop filter samples."""
@@ -191,7 +193,7 @@ class BaseExciseSampleMaker(BaseSampleMaker):
         self,
         substructure: AXL,
         num_samples: int = 1,
-    ) -> List[AXL]:
+    ) -> Tuple[List[AXL], List[Dict[str, Any]]]:
         """Create new samples using a constrained structure.
 
         Args:
@@ -200,6 +202,7 @@ class BaseExciseSampleMaker(BaseSampleMaker):
 
         Returns:
             list of samples created. The length of the list should match num_samples.
+            list of samples additional information.
         """
         pass
 
@@ -290,7 +293,7 @@ class BaseExciseSampleMaker(BaseSampleMaker):
         self,
         structure: AXL,
         uncertainty_per_atom: np.array,
-    ) -> List[AXL]:
+    ) -> Tuple[List[AXL], List[Dict[str, Any]]]:
         """Make new samples based on the excised substructures created using the uncertainties.
 
         Args:
@@ -301,12 +304,17 @@ class BaseExciseSampleMaker(BaseSampleMaker):
 
         Returns:
             created_samples: list of generated samples as AXL structures
+            created_samples_info: list of dictionary with additional information on the created samples
         """
-        constrained_environments_after_excision = (
+        constrained_environments_after_excision, central_atom_indices = (
             self.environment_excisor.excise_environments(
                 structure, uncertainty_per_atom, center_atoms=True
             )
         )
+        assert len(constrained_environments_after_excision) == len(
+            central_atom_indices
+        ), "Number of excised environment do not match the number of central atom index. Something went wrong."
+
         if (
             self.arguments.max_constrained_substructure
             != _UNLIMITED_CONSTRAINED_STRUCTURE
@@ -319,8 +327,14 @@ class BaseExciseSampleMaker(BaseSampleMaker):
                     : self.arguments.max_constrained_substructure
                 ]
             )
+            central_atom_indices = central_atom_indices[
+                : self.arguments.max_constrained_substructure
+            ]
         created_samples = []
-        for constrained_environment in constrained_environments_after_excision:
+        created_samples_info = []
+        for constrained_environment, central_atom_index in zip(
+            constrained_environments_after_excision, central_atom_indices
+        ):
             if self.sample_box_strategy == "fixed":
                 constrained_environment_in_new_box = self.embed_structure_in_new_box(
                     constrained_environment, self.arguments.new_box_lattice_parameters
@@ -328,12 +342,26 @@ class BaseExciseSampleMaker(BaseSampleMaker):
             # TODO use the L diffusion to get a new box
             else:  # noop
                 constrained_environment_in_new_box = constrained_environment
-            new_samples = self.make_samples_from_constrained_substructure(
-                constrained_environment_in_new_box,
-                self.arguments.number_of_samples_per_substructure,
+            new_samples, new_samples_info = (
+                self.make_samples_from_constrained_substructure(
+                    constrained_environment_in_new_box,
+                    self.arguments.number_of_samples_per_substructure,
+                )
             )
             created_samples += new_samples
-        return created_samples
+
+            new_samples_info_updated = []
+            for sample_info in new_samples_info:
+                sample_info.update(central_atom_index)
+                sample_info.update(
+                    {
+                        AXL_STRUCTURE_IN_ORIGINAL_BOX: constrained_environment,
+                        AXL_STRUCTURE_IN_NEW_BOX: constrained_environment_in_new_box,
+                    }
+                )
+                new_samples_info_updated.append(sample_info)
+            created_samples_info += new_samples_info_updated
+        return created_samples, created_samples_info
 
 
 @dataclass(kw_only=True)
@@ -359,8 +387,9 @@ class NoOpExciseSampleMaker(BaseExciseSampleMaker):
 
         Returns:
             list of samples created. The length of the list should match num_samples.
+            list of additional information on samples created.
         """
-        return [substructure] * num_samples
+        return [substructure] * num_samples, [{}] * num_samples
 
     def filter_made_samples(self, structures: List[AXL]) -> List[AXL]:
         """Return identical structures."""

--- a/src/diffusion_for_multi_scale_molecular_dynamics/active_learning_loop/sample_maker/excise_and_repaint_sample_maker.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/active_learning_loop/sample_maker/excise_and_repaint_sample_maker.py
@@ -137,7 +137,11 @@ class ExciseAndRepaintSampleMaker(BaseExciseSampleMaker):
         new_structures = self.torch_batch_axl_to_list_of_numpy_axl(
             generated_samples["original_axl"]
         )
-        return new_structures
+
+        # additional information on generated structures can be passed here
+        additional_information_on_new_structures = [{}] * len(new_structures)
+
+        return new_structures, additional_information_on_new_structures
 
     def filter_made_samples(self, structures: List[AXL]) -> List[AXL]:
         """Return identical structures."""

--- a/src/diffusion_for_multi_scale_molecular_dynamics/active_learning_loop/single_point_calculators/base_single_point_calculator.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/active_learning_loop/single_point_calculators/base_single_point_calculator.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Dict, Optional
 
 import numpy as np
 from pymatgen.core import Structure
@@ -9,11 +9,13 @@ from pymatgen.core import Structure
 @dataclass(kw_only=True)
 class SinglePointCalculation:
     """A data structure to hold the output of a single point calculator."""
+
     calculation_type: str
     structure: Structure
     forces: np.ndarray
     energy: float
     uncertainties: Optional[np.ndarray] = None
+    additional_information: Optional[Dict[str, Any]] = None
 
 
 class BaseSinglePointCalculator:
@@ -22,6 +24,7 @@ class BaseSinglePointCalculator:
     This base class defines the interface for performing "single-point" MLIP calculations.
     Here, "single-point" means a single structure, as opposed to, say, a trajectory.
     """
+
     def __init__(self, args, **kwargs):
         """Init method."""
         pass

--- a/tests/active_learning_loop/sample_maker/test_base_sample_maker.py
+++ b/tests/active_learning_loop/sample_maker/test_base_sample_maker.py
@@ -21,7 +21,7 @@ class TestBaseExciseSampleMaker:
 
     @staticmethod
     def trivial_make_samples_from_constraints_method(substructure, num_samples):
-        return [substructure] * num_samples
+        return [substructure] * num_samples, [{}] * num_samples
 
     @pytest.fixture(params=[1, 2, 3])
     def spatial_dimension(self, request):
@@ -93,7 +93,7 @@ class TestBaseExciseSampleMaker:
         uncertainty_per_atom,
         num_samples,
     ):
-        made_samples = noop_base_excise_sample_maker.make_samples(
+        made_samples, _ = noop_base_excise_sample_maker.make_samples(
             structure_axl, uncertainty_per_atom
         )
         assert (

--- a/tests/active_learning_loop/sample_maker/test_excise_and_repaint_sample_maker.py
+++ b/tests/active_learning_loop/sample_maker/test_excise_and_repaint_sample_maker.py
@@ -225,8 +225,10 @@ class TestExciseAndRepaintSampleMaker:
             "excise_and_repaint_sample_maker.create_batch_of_samples",
             new=mock_create_batch_of_samples,
         ):
-            calculated_new_samples = excise_and_repaint_sample_maker.make_samples_from_constrained_substructure(
-                constrained_axl
+            calculated_new_samples, _ = (
+                excise_and_repaint_sample_maker.make_samples_from_constrained_substructure(
+                    constrained_axl
+                )
             )
 
         mock_create_batch_of_samples.assert_called_once()


### PR DESCRIPTION
In this PR, I added dictionaries of additional informations from samples. This exposes the central atom index when using an Excision sample maker. This should make the ExciseAndRepaintSampleMaker compatible with the current AL code (fingers crossed, I am limited in my current testing from a non-working env - I'll try working in a podman to test stuff).