### PR TITLE
Better auxiliary information

### DIFF
--- a/src/diffusion_for_multi_scale_molecular_dynamics/active_learning_loop/active_learning.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/active_learning_loop/active_learning.py
@@ -154,14 +154,14 @@ class ActiveLearning:
 
             constrained_indices = sample_information["constrained_atom_indices"]
             structure = calculation.structure
-            constraint_mask = np.zeros(len(structure), dtype=bool)
-            constraint_mask[constrained_indices] = True
+            constraint_mask = np.zeros(len(structure), dtype=int)
+            constraint_mask[constrained_indices] = 1
             structure.add_site_property('constrained', constraint_mask)
+            structure.add_site_property('forces', calculation.forces)
 
             row = dict(
                 calculation_type=calculation.calculation_type,
                 structure=structure,
-                forces=calculation.forces,
                 energy=calculation.energy,
             )
             rows.append(row)

--- a/src/diffusion_for_multi_scale_molecular_dynamics/active_learning_loop/active_learning.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/active_learning_loop/active_learning.py
@@ -151,12 +151,18 @@ class ActiveLearning:
         for calculation, sample_information in zip(
             list_single_point_calculations, list_sample_information
         ):
+
+            constrained_indices = sample_information["constrained_atom_indices"]
+            structure = calculation.structure
+            constraint_mask = np.zeros(len(structure), dtype=bool)
+            constraint_mask[constrained_indices] = True
+            structure.add_site_property('constrained', constraint_mask)
+
             row = dict(
                 calculation_type=calculation.calculation_type,
-                structure=calculation.structure,
+                structure=structure,
                 forces=calculation.forces,
                 energy=calculation.energy,
-                sample_information=sample_information,
             )
             rows.append(row)
 

--- a/src/diffusion_for_multi_scale_molecular_dynamics/active_learning_loop/sample_maker/base_sample_maker.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/active_learning_loop/sample_maker/base_sample_maker.py
@@ -133,6 +133,29 @@ class BaseSampleMaker(ABC):
                     f"{self.arguments.sample_box_strategy} is an invalid box making strategy."
                 )
 
+    def _create_sample_info_dictionary(self, axl_structure: AXL) -> Dict[str, Any]:
+        """Create sample info dictionary.
+
+        This utility method will create an "info" dictionary that captures the indices
+        describing the atoms in the input structure.
+
+        The usefulness of this method is in distinguishing the indices of the atoms in
+        the initial structure with an uncertain atom from the atoms that are then (potentially)
+        generated.
+
+        This assumes that any new atoms added to a structure by "repaint" will always be
+        appended to existing "constrained" atoms.
+
+        Args:
+            axl_structure: structure as an AXL object.
+
+        Returns:
+            sample_info_dict: A Dictionary containing useful information about the input structure.
+        """
+        number_of_atoms = len(axl_structure.X)
+        sample_info_dict = dict(constrained_atom_indices=list(range(number_of_atoms)))
+        return sample_info_dict
+
 
 @dataclass(kw_only=True)
 class BaseExciseSampleMakerArguments(BaseSampleMakerArguments):

--- a/src/diffusion_for_multi_scale_molecular_dynamics/active_learning_loop/sample_maker/excise_and_noop_sample_maker.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/active_learning_loop/sample_maker/excise_and_noop_sample_maker.py
@@ -38,7 +38,7 @@ class ExciseAndNoOpSampleMaker(BaseExciseSampleMaker):
         """
         list_samples = num_samples * [substructure]
         list_active_atom_indices = num_samples * [active_atom_index]
-        list_info = num_samples * [{}]
+        list_info = [self._create_sample_info_dictionary(substructure) for _ in range(num_samples)]
         return list_samples, list_active_atom_indices, list_info
 
     def filter_made_samples(self, structures: List[AXL]) -> List[AXL]:

--- a/src/diffusion_for_multi_scale_molecular_dynamics/active_learning_loop/sample_maker/excise_and_random_sample_maker.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/active_learning_loop/sample_maker/excise_and_random_sample_maker.py
@@ -206,6 +206,7 @@ class ExciseAndRandomSampleMaker(BaseExciseSampleMaker):
         )  # the atoms at those coordinates will be replaced by the constrained atoms
         new_relative_coordinates_copy = new_relative_coordinates.copy()
         # replace some relative coordinates by those of the constrained atoms
+        replacement_indices = []
 
         new_active_atom_index = None
         for constrained_structure_atom_index, (constrained_atom_x, constrained_atom_a) in enumerate(zip(
@@ -229,17 +230,34 @@ class ExciseAndRandomSampleMaker(BaseExciseSampleMaker):
                     atom_indices_replaced.append(atom_idx)
                     new_relative_coordinates_copy[atom_idx] = constrained_atom_x
                     new_atom_types[atom_idx] = constrained_atom_a
+                    replacement_indices.append(atom_idx)
                     if active_atom:
                         assert new_active_atom_index is None, \
                             "Trying to set the new_active_index more than once! Something is wrong."
                         new_active_atom_index = atom_idx
                     break
 
-        new_structure = AXL(A=new_atom_types, X=new_relative_coordinates_copy, L=lattice_parameters)
+        # Shuffle the atom order to ensure that the constrained atoms come first.
+        # We use a MASK to extract all the generated atoms; their order doesn't matter.
+        # However, we extract the constrained coordinates exactly in the order defined
+        # by the index array "replacement_indices": using a MASK here might shuffle their order!
+        generated_atoms_mask = np.ones(len(new_relative_coordinates), dtype=bool)
+        generated_atoms_mask[replacement_indices] = False
+
+        atom_types = np.concatenate([new_atom_types[replacement_indices],
+                                     new_atom_types[generated_atoms_mask]])
+
+        relative_coordinates = np.vstack([new_relative_coordinates_copy[replacement_indices],
+                                          new_relative_coordinates_copy[generated_atoms_mask]])
+
+        new_structure = AXL(A=atom_types, X=relative_coordinates, L=lattice_parameters)
 
         assert new_active_atom_index is not None, "The new active atom index is not set. Something went wrong."
+        # The active atom index should be one of the replacement_indices since it is part of the
+        # constrained set of atoms.
+        active_atom_idx = replacement_indices.index(new_active_atom_index)
 
-        return new_structure, new_active_atom_index
+        return new_structure, active_atom_idx
 
     @staticmethod
     def get_shortest_distance_between_atoms(

--- a/src/diffusion_for_multi_scale_molecular_dynamics/active_learning_loop/sample_maker/excise_and_random_sample_maker.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/active_learning_loop/sample_maker/excise_and_random_sample_maker.py
@@ -333,14 +333,15 @@ class ExciseAndRandomSampleMaker(BaseExciseSampleMaker):
         """
         list_sample_structures = []
         list_active_atom_indices = []
+        additional_information_on_new_structures = []
         for _ in range(num_samples):
             new_structure, new_active_index = self.make_single_sample_from_constrained_substructure(substructure,
                                                                                                     active_atom_index)
             list_sample_structures.append(new_structure)
             list_active_atom_indices.append(new_active_index)
-
             # additional information on generated structures can be passed here
-        additional_information_on_new_structures = [{}] * len(list_sample_structures)
+            additional_information_on_new_structures.append(self._create_sample_info_dictionary(substructure))
+
         return list_sample_structures, list_active_atom_indices, additional_information_on_new_structures
 
     def filter_made_samples(self, structures: List[AXL]) -> List[AXL]:

--- a/src/diffusion_for_multi_scale_molecular_dynamics/active_learning_loop/sample_maker/excise_and_repaint_sample_maker.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/active_learning_loop/sample_maker/excise_and_repaint_sample_maker.py
@@ -190,7 +190,9 @@ class ExciseAndRepaintSampleMaker(BaseExciseSampleMaker):
         list_active_atom_indices = num_samples * [active_atom_index]
 
         # additional information on generated structures can be passed here
-        additional_information_on_new_structures = [{}] * len(new_structures)
+        additional_information_on_new_structures = []
+        for _ in range(len(new_structures)):
+            additional_information_on_new_structures.append(self._create_sample_info_dictionary(substructure))
 
         return new_structures, list_active_atom_indices, additional_information_on_new_structures
 

--- a/src/diffusion_for_multi_scale_molecular_dynamics/active_learning_loop/sample_maker/no_op_sample_maker.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/active_learning_loop/sample_maker/no_op_sample_maker.py
@@ -36,7 +36,7 @@ class NoOpSampleMaker(BaseSampleMaker):
     ) -> Tuple[List[AXL], List[np.array], List[Dict[str, Any]]]:
         """Noop make samples."""
         central_atom_indices = self.atom_selector.select_central_atoms(uncertainty_per_atom)
-        return [structure], [central_atom_indices], [{}]
+        return [structure], [central_atom_indices], [self._create_sample_info_dictionary(structure)]
 
     def filter_made_samples(self, structures: List[AXL]) -> List[AXL]:
         """Noop filter samples."""

--- a/src/diffusion_for_multi_scale_molecular_dynamics/analysis/ovito_utilities/generated_samples_io.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/analysis/ovito_utilities/generated_samples_io.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+from pymatgen.core import Structure
+
+from diffusion_for_multi_scale_molecular_dynamics.analysis.ovito_utilities.xyz_utils import \
+    generate_xyz_text
+
+
+def write_active_learning_generated_sample(structure: Structure, output_path: Path):
+    """Write active learning generated samples.
+
+    This method assumes that the input structure has 'constrained' and 'forces' site properties.
+
+    Args:
+        structure (Structure): Structure object.
+        output_path (Path): Path where to write the xyz output.
+
+    Returns:
+        None
+    """
+    properties_dim = dict(constrained=1, forces=3)
+    site_properties = list(properties_dim.keys())
+
+    for key in site_properties:
+        assert key in structure.site_properties, f"The input structure is mising the site property {key}"
+
+    xyz_text = generate_xyz_text(structure, site_properties, properties_dim)
+
+    with open(output_path, 'w') as fd:
+        fd.write(xyz_text)

--- a/src/diffusion_for_multi_scale_molecular_dynamics/analysis/ovito_utilities/xyz_utils.py
+++ b/src/diffusion_for_multi_scale_molecular_dynamics/analysis/ovito_utilities/xyz_utils.py
@@ -1,0 +1,64 @@
+from typing import Dict, List, Optional, Union
+
+import numpy as np
+from pymatgen.core import Structure
+
+
+def generate_xyz_text(
+    structure: Structure,
+    site_properties: Optional[Union[str, List[str]]],
+    properties_dim: Optional[Dict[str, int]]
+):
+    """Generate XYZ text.
+
+    This method transforms a pymatgen structure and attendant
+    site properties into text in the xyz format.
+
+    Args:
+        structure: pymatgen structure to convert
+        site_properties: atomic properties names
+        properties_dim: A dictionary defining the dimensionality of each site property.
+
+    Returns:
+        xyz_text: a string in the xyz format, ready to be dumped to file.
+    """
+    lattice = structure.lattice._matrix
+    lattice = list(
+        map(str, lattice.flatten())
+    )  # flatten and convert to string for formatting
+    lattice_str = 'Lattice="' + " ".join(lattice) + '" Origin="0 0 0" pbc="T T T"'
+
+    n_atom = len(structure.sites)
+    if site_properties is None:
+        site_properties = []
+        properties_dim = []
+
+    elif site_properties is not None and isinstance(site_properties, str):
+        site_properties = [site_properties]
+        assert (
+            properties_dim is not None
+        ), "site properties are defined, but dimensionalities are not."
+
+    if properties_dim is not None:
+        properties_dim = [properties_dim[k] for k in site_properties]
+
+    assert len(properties_dim) == len(
+        site_properties
+    ), "mismatch between number of site properties names and dimensions"
+
+    xyz_txt = f"{n_atom}\n"
+    xyz_txt += lattice_str + " Properties=pos:R:3"
+    for prop, prop_dim in zip(site_properties, properties_dim):
+        xyz_txt += f":{prop}:R:{prop_dim}"
+    xyz_txt += "\n"
+    for i in range(n_atom):
+        positions_values = structure.sites[i].coords
+        xyz_txt += " ".join(map(str, positions_values))
+        for prop in site_properties:
+            prop_value = structure.sites[i].properties.get(prop, 0)
+            if not isinstance(prop_value, (list, np.ndarray)):
+                prop_value = [prop_value]
+            xyz_txt += f" {' '.join(map(str, prop_value))}"
+        xyz_txt += "\n"
+
+    return xyz_txt


### PR DESCRIPTION
In this PR, I jiggle things around a bit to make it much easier to generate ovito visualizations like this:

<img width="1118" alt="Screenshot 2025-07-04 at 4 39 57 PM" src="https://github.com/user-attachments/assets/2b774bf0-131a-4182-888b-8154ecd76ebe" />

where it is easy to distinguish the constrained atoms (red) from the generated atoms (blue). 